### PR TITLE
Update to 1.9 [WIP] Resolves #111

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,143 +1,111 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.dre</groupId>
-	<artifactId>brewery</artifactId>
-	<version>1.3.2</version>
-	<name>Brewery</name>
+    <groupId>com.dre</groupId>
+    <artifactId>brewery</artifactId>
+    <version>1.4-SNAPSHOT</version>
+    <name>Brewery</name>
 
-	<properties>
-	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 
-	<build>
-		<sourceDirectory>src</sourceDirectory>
+    <build>
+        <sourceDirectory>src</sourceDirectory>
 
-		<resources>
-			<!-- Static resources -->
-			<resource>
-				<filtering>false</filtering>
-				<directory>${project.basedir}/resources</directory>
-				<includes>
-					<include>**/*.yml</include>
-				</includes>
-				<excludes>
-					<exclude>target/**</exclude>
-					<exclude>.travis.yml</exclude>
-				</excludes>
-			</resource>
-		</resources>
+        <resources>
+            <!-- Static resources -->
+            <resource>
+                <filtering>false</filtering>
+                <directory>${project.basedir}/resources</directory>
+                <includes>
+                    <include>**/*.yml</include>
+                </includes>
+                <excludes>
+                    <exclude>target/**</exclude>
+                    <exclude>.travis.yml</exclude>
+                </excludes>
+            </resource>
+        </resources>
 
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-	<repositories>
-		<repository>
-			<id>spigot-repo</id>
-			<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-		</repository>
-
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+        </repository>
         <repository>
             <id>vault-repo</id>
             <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
         </repository>
+        <repository>
+            <id>dre2n-repo</id>
+            <url>http://feuerstern.bplaced.net/repo/</url>
+        </repository>
+        <repository>
+            <id>sk89q-repo</id>
+            <url>http://maven.sk89q.com/artifactory/repo/</url>
+        </repository>
+        <repository>
+            <id>addstar-repo</id>
+            <url>http://maven.addstar.com.au/artifactory/ext-release-local/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>md_5-releases</id>
+            <url>http://repo.md-5.net/content/repositories/releases/</url>
+        </repository>
+    </repositories>
 
-		<repository>
-			<id>sk89q-repo</id>
-			<url>http://maven.sk89q.com/artifactory/repo/</url>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-		</repository>
-
-		<repository>
-			<id>dre-repo</id>
-			<url>http://server.die-reiche-erethons.com/maven2</url>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-		</repository>
-
-		<repository>
-			<id>addstar-repo</id>
-			<url>http://maven.addstar.com.au/artifactory/ext-release-local/</url>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-		</repository>
-
-	</repositories>
-
-	<dependencies>
-		<!-- Provided by third-party -->
-		<dependency>
-			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot-api</artifactId>
-			<version>1.8-R0.1-SNAPSHOT</version>
-		</dependency>
-
+    <dependencies>
+        <dependency>
+            <groupId>org.bukkit</groupId>
+            <artifactId>bukkit</artifactId>
+            <version>1.9-R0.1-SNAPSHOT</version>
+        </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.5</version>
             <scope>provided</scope>
         </dependency>
-
-		<dependency>
-			<groupId>com.sk89q</groupId>
-			<artifactId>worldguard</artifactId>
-			<version>6.0.0-SNAPSHOT</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.dre</groupId>
-			<artifactId>managerxl</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
-			<scope>compile</scope>
-			<type>jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>com.griefcraft</groupId>
-			<artifactId>lwc</artifactId>
-			<version>4.4.0</version>
-			<scope>compile</scope>
-			<type>jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>me.ryanhamshire</groupId>
-			<artifactId>griefprevention</artifactId>
-			<version>7.8</version>
-			<scope>compile</scope>
-			<type>jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>de.diddiz.LogBlock</groupId>
-			<artifactId>LogBlock</artifactId>
-			<version>1.80</version>
-			<scope>compile</scope>
-			<type>jar</type>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>com.sk89q</groupId>
+            <artifactId>worldguard</artifactId>
+            <version>6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.griefcraft</groupId>
+            <artifactId>entitylwc</artifactId>
+            <version>1.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>me.ryanhamshire</groupId>
+            <artifactId>GriefPrevention</artifactId>
+            <version>13.9.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.diddiz</groupId>
+            <artifactId>logblock</artifactId>
+            <version>1.94</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Brewery
-version: 1.3.2
+version: 1.4-SNAPSHOT
 main: com.dre.brewery.P
 authors: [Milan Albrecht, Frank Baumann]
 softdepend: [LWC, LogBlock, WorldGuard, GriefPrevention, Vault]

--- a/src/com/dre/brewery/BIngredients.java
+++ b/src/com/dre/brewery/BIngredients.java
@@ -1,16 +1,15 @@
 package com.dre.brewery;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Set;
-
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.Material;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionEffectType;
 
 public class BIngredients {
 	public static Set<Material> possibleIngredients = new HashSet<Material>();
@@ -84,7 +83,11 @@ public class BIngredients {
 			Brew.addOrReplaceEffects(potionMeta, brew.getEffects(), brew.getQuality());
 
 			cookedName = cookRecipe.getName(quality);
-			potion.setDurability(Brew.PotionColor.valueOf(cookRecipe.getColor()).getColorId(false));
+                        if (P.use1_9) {
+                            potionMeta.setMainEffect(Brew.PotionColor.valueOf(cookRecipe.getColor()).getEffect());
+                        } else {
+                            potion.setDurability(Brew.PotionColor.valueOf(cookRecipe.getColor()).getColorId(false));
+                        }
 
 		} else {
 			// new base potion
@@ -92,14 +95,22 @@ public class BIngredients {
 
 			if (state <= 1) {
 				cookedName = P.p.languageReader.get("Brew_ThickBrew");
-				potion.setDurability(Brew.PotionColor.BLUE.getColorId(false));
+                                if (P.use1_9) {
+                                    potionMeta.setMainEffect(Brew.PotionColor.BLUE.getEffect());
+                                } else {
+                                    potion.setDurability(Brew.PotionColor.BLUE.getColorId(false));
+                                }
 			} else {
 				for (Material ingredient : materials.keySet()) {
 					if (cookedNames.containsKey(ingredient)) {
 						// if more than half of the ingredients is of one kind
 						if (materials.get(ingredient) > (getIngredientsCount() / 2)) {
 							cookedName = cookedNames.get(ingredient);
-							potion.setDurability(Brew.PotionColor.CYAN.getColorId(true));
+                                                        if (P.use1_9) {
+                                                            potionMeta.setMainEffect(Brew.PotionColor.CYAN.getEffect());
+                                                        } else {
+                                                            potion.setDurability(Brew.PotionColor.CYAN.getColorId(true));
+                                                        }
 						}
 					}
 				}
@@ -108,7 +119,11 @@ public class BIngredients {
 		if (cookedName == null) {
 			// if no name could be found
 			cookedName = P.p.languageReader.get("Brew_Undefined");
-			potion.setDurability(Brew.PotionColor.CYAN.getColorId(true));
+                        if (P.use1_9) {
+                            potionMeta.setMainEffect(Brew.PotionColor.CYAN.getEffect());
+                        } else {
+                            potion.setDurability(Brew.PotionColor.CYAN.getColorId(true));
+                        }
 		}
 
 		potionMeta.setDisplayName(P.p.color("&f" + cookedName));

--- a/src/com/dre/brewery/BPlayer.java
+++ b/src/com/dre/brewery/BPlayer.java
@@ -1,22 +1,21 @@
 package com.dre.brewery;
 
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.UUID;
-
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.entity.Player;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.Material;
-import org.bukkit.util.Vector;
-import org.bukkit.Location;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.util.Vector;
 
 public class BPlayer {
 	private static Map<String, BPlayer> players = new HashMap<String, BPlayer>();// Players name/uuid and BPlayer
@@ -339,10 +338,6 @@ public class BPlayer {
 			Location home = null;
 			if (homeType.equalsIgnoreCase("bed")) {
 				home = player.getBedSpawnLocation();
-			} else if (homeType.equalsIgnoreCase("ManagerXL")) {
-				if (com.dre.managerxl.MPlayer.get(player.getName()) != null) {
-					home = com.dre.managerxl.MPlayer.get(player.getName()).getHome();
-				}
 			} else if (homeType.startsWith("cmd: ")) {
 				player.performCommand(homeType.substring(5));
 			} else if (homeType.startsWith("cmd:")) {

--- a/src/com/dre/brewery/BRecipe.java
+++ b/src/com/dre/brewery/BRecipe.java
@@ -2,9 +2,8 @@ package com.dre.brewery;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffectType;
@@ -205,7 +204,11 @@ public class BRecipe {
 
 		Brew brew = new Brew(uid, bIngredients, quality, distillruns, getAge(), wood, getName(5), false, false, true);
 
-		potion.setDurability(Brew.PotionColor.valueOf(getColor()).getColorId(false));
+                if (P.use1_9) {
+                    potionMeta.setMainEffect(Brew.PotionColor.valueOf(getColor()).getEffect());
+                } else {
+                    potion.setDurability(Brew.PotionColor.valueOf(getColor()).getColorId(false));
+                }
 		potionMeta.setDisplayName(P.p.color("&f" + getName(quality)));
 		// This effect stores the UID in its Duration
 		potionMeta.addCustomEffect((PotionEffectType.REGENERATION).createEffect((uid * 4), 0), true);

--- a/src/com/dre/brewery/Brew.java
+++ b/src/com/dre/brewery/Brew.java
@@ -1,677 +1,699 @@
 package com.dre.brewery;
 
-import java.util.Map;
-import java.util.HashMap;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.BrewerInventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.inventory.BrewerInventory;
 
 public class Brew {
 
-	// represents the liquid in the brewed Potions
-
-	public static Map<Integer, Brew> potions = new HashMap<Integer, Brew>();
-	public static Boolean colorInBarrels; // color the Lore while in Barrels
-	public static Boolean colorInBrewer; // color the Lore while in Brewer
-
-	private BIngredients ingredients;
-	private int quality;
-	private int distillRuns;
-	private float ageTime;
-	private float wood;
-	private BRecipe currentRecipe;
-	private boolean unlabeled;
-	private boolean persistent;
-	private boolean stat; // static potions should not be changed
-
-	public Brew(int uid, BIngredients ingredients) {
-		this.ingredients = ingredients;
-		potions.put(uid, this);
-	}
-
-	// quality already set
-	public Brew(int uid, int quality, BRecipe recipe, BIngredients ingredients) {
-		this.ingredients = ingredients;
-		this.quality = quality;
-		this.currentRecipe = recipe;
-		potions.put(uid, this);
-	}
-
-	// loading from file
-	public Brew(int uid, BIngredients ingredients, int quality, int distillRuns, float ageTime, float wood, String recipe, boolean unlabeled, boolean persistent, boolean stat) {
-		potions.put(uid, this);
-		this.ingredients = ingredients;
-		this.quality = quality;
-		this.distillRuns = distillRuns;
-		this.ageTime = ageTime;
-		this.wood = wood;
-		this.unlabeled = unlabeled;
-		this.persistent = persistent;
-		this.stat = stat;
-		setRecipeFromString(recipe);
-	}
-
-	// returns a Brew by its UID
-	public static Brew get(int uid) {
-		if (uid < -1) {
-			if (!potions.containsKey(uid)) {
-				P.p.errorLog("Database failure! unable to find UID " + uid + " of a custom Potion!");
-				return null;// throw some exception?
-			}
-		} else {
-			return null;
-		}
-		return potions.get(uid);
-	}
-
-	// returns a Brew by PotionMeta
-	public static Brew get(PotionMeta meta) {
-		return get(getUID(meta));
-	}
-
-	// returns a Brew by ItemStack
-	public static Brew get(ItemStack item) {
-		if (item.getType() == Material.POTION) {
-			if (item.hasItemMeta()) {
-				PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
-				return get(potionMeta);
-			}
-		}
-		return null;
-	}
-
-
-	// returns UID of custom Potion item
-	public static int getUID(ItemStack item) {
-		return getUID((PotionMeta) item.getItemMeta());
-	}
-
-	// returns UID of custom Potion meta
-	public static int getUID(PotionMeta potionMeta) {
-		if (potionMeta.hasCustomEffect(PotionEffectType.REGENERATION)) {
-			for (PotionEffect effect : potionMeta.getCustomEffects()) {
-				if (effect.getType().equals(PotionEffectType.REGENERATION)) {
-					if (effect.getDuration() < -1) {
-						return effect.getDuration();
-					}
-				}
-			}
-		}
-		return 0;
-	}
-
-	// generate an UID
-	public static int generateUID() {
-		int uid = -2;
-		while (potions.containsKey(uid)) {
-			uid -= 1;
-		}
-		return uid;
-	}
-
-	//returns the recipe with the given name, recalculates if not found
-	public boolean setRecipeFromString(String name) {
-		currentRecipe = null;
-		if (name != null && !name.equals("")) {
-			for (BRecipe recipe : BIngredients.recipes) {
-				if (recipe.getName(5).equalsIgnoreCase(name)) {
-					currentRecipe = recipe;
-					return true;
-				}
-			}
-
-			if (quality > 0) {
-				currentRecipe = ingredients.getBestRecipe(wood, ageTime, distillRuns > 0);
-				if (currentRecipe != null) {
-					if (!stat) {
-						this.quality = calcQuality();
-					}
-					P.p.log("Brew was made from Recipe: '" + name + "' which could not be found. '" + currentRecipe.getName(5) + "' used instead!");
-					return true;
-				} else {
-					P.p.errorLog("Brew was made from Recipe: '" + name + "' which could not be found!");
-				}
-			}
-		}
-		return false;
-	}
-
-	public boolean reloadRecipe() {
-		if (currentRecipe != null) {
-			return setRecipeFromString(currentRecipe.getName(5));
-		}
-		return true;
-	}
-
-	// Copy a Brew with a new unique ID and return its item
-	public ItemStack copy(ItemStack item) {
-		ItemStack copy = item.clone();
-		int uid = generateUID();
-		clone(uid);
-		PotionMeta meta = (PotionMeta) copy.getItemMeta();
-		meta.addCustomEffect((PotionEffectType.REGENERATION).createEffect((uid * 4), 0), true);
-		copy.setItemMeta(meta);
-		return copy;
-	}
-
-	// Clones this instance with a new unique ID
-	public Brew clone(int uid) {
-		Brew brew = new Brew(uid, quality, currentRecipe, ingredients);
-		brew.distillRuns = distillRuns;
-		brew.ageTime = ageTime;
-		brew.unlabeled = unlabeled;
-		if (!brew.persistent) {
-			brew.stat = stat;
-		}
-		return brew;
-	}
-
-	// remove potion from file (drinking, despawning, combusting, cmdDeleting, should be more!)
-	public void remove(ItemStack item) {
-		if (!persistent) {
-			potions.remove(getUID(item));
-		}
-	}
-
-	// calculate alcohol from recipe
-	public int calcAlcohol() {
-		if (quality == 0) {
-			// Give bad potions some alc
-			int badAlc = 0;
-			if (distillRuns > 1) {
-				badAlc = distillRuns;
-			}
-			if (ageTime > 10) {
-				badAlc += 5;
-			} else if (ageTime > 2) {
-				badAlc += 3;
-			}
-			if (currentRecipe != null) {
-				return badAlc;
-			} else {
-				return badAlc / 2;
-			}
-		}
-
-		if (currentRecipe != null) {
-			int alc = currentRecipe.getAlcohol();
-			if (currentRecipe.needsDistilling()) {
-				if (distillRuns == 0) {
-					return 0;
-				}
-				// bad quality can decrease alc by up to 40%
-				alc *= 1 - ((float) (10 - quality) * 0.04);
-				// distillable Potions should have half alc after one and full alc after all needed distills
-				alc /= 2;
-				alc *= 1.0F + ((float) distillRuns / currentRecipe.getDistillRuns()) ;
-			} else {
-				// quality decides 10% - 100%
-				alc *= ((float) quality / 10.0);
-			}
-			if (alc > 0) {
-				return alc;
-			}
-		}
-		return 0;
-	}
-
-	// calculating quality
-	public int calcQuality() {
-		// calculate quality from all of the factors
-		float quality = ingredients.getIngredientQuality(currentRecipe) + ingredients.getCookingQuality(currentRecipe, distillRuns > 0);
-		if (currentRecipe.needsToAge() || ageTime > 0.5) {
-			quality += ingredients.getWoodQuality(currentRecipe, wood) + ingredients.getAgeQuality(currentRecipe, ageTime);
-			quality /= 4;
-		} else {
-			quality /= 2;
-		}
-		return Math.round(quality);
-	}
-
-	public int getQuality() {
-		return quality;
-	}
-
-	public boolean canDistill() {
-		if (currentRecipe != null) {
-			return currentRecipe.getDistillRuns() > distillRuns;
-		} else if (distillRuns >= 6) {
-			return false;
-		}
-		return true;
-	}
-
-	// return special effect
-	public ArrayList<BEffect> getEffects() {
-		if (currentRecipe != null && quality > 0) {
-			return currentRecipe.getEffects();
-		}
-		return null;
-	}
-
-	// Set unlabeled to true to hide the numbers in Lore
-	public void unLabel(ItemStack item) {
-		PotionMeta meta = (PotionMeta) item.getItemMeta();
-		if (meta.hasLore()) {
-			if (distillRuns > 0) {
-				addOrReplaceLore(meta, P.p.color("&7"), P.p.languageReader.get("Brew_Distilled"));
-			}
-			if (ageTime >= 1) {
-				addOrReplaceLore(meta, P.p.color("&7"), P.p.languageReader.get("Brew_BarrelRiped"));
-			}
-			item.setItemMeta(meta);
-		}
-		unlabeled = true;
-	}
-
-	public boolean isPersistent() {
-		return persistent;
-	}
-
-	// Make a potion persistent to not delete it when drinking it
-	public void makePersistent() {
-		persistent = true;
-	}
-
-	// Remove the Persistence Flag from a brew, so it will be normally deleted when drinking it
-	public void removePersistence() {
-		persistent = false;
-	}
-
-	public boolean isStatic() {
-		return stat;
-	}
-
-	// Set the Static flag, so potion is unchangeable
-	public void setStatic(boolean stat, ItemStack potion) {
-		this.stat = stat;
-		if (currentRecipe != null && canDistill()) {
-			if (stat) {
-				potion.setDurability(PotionColor.valueOf(currentRecipe.getColor()).getColorId(false));
-			} else {
-				potion.setDurability(PotionColor.valueOf(currentRecipe.getColor()).getColorId(true));
-			}
-		}
-	}
-
-	// Distilling section ---------------
-
-	// distill all custom potions in the brewer
-	public static void distillAll(BrewerInventory inv, Boolean[] contents) {
-		int slot = 0;
-		while (slot < 3) {
-			if (contents[slot]) {
-				ItemStack slotItem = inv.getItem(slot);
-				PotionMeta potionMeta = (PotionMeta) slotItem.getItemMeta();
-				Brew brew = get(potionMeta);
-				brew.distillSlot(slotItem, potionMeta);
-			}
-			slot++;
-		}
-	}
-
-	// distill custom potion in given slot
-	public void distillSlot(ItemStack slotItem, PotionMeta potionMeta) {
-		if (stat) {
-			return;
-		}
-
-		distillRuns += 1;
-		BRecipe recipe = ingredients.getdistillRecipe(wood, ageTime);
-		if (recipe != null) {
-			// distillRuns will have an effect on the amount of alcohol, not the quality
-			currentRecipe = recipe;
-			quality = calcQuality();
-
-			addOrReplaceEffects(potionMeta, getEffects(), quality);
-			potionMeta.setDisplayName(P.p.color("&f" + recipe.getName(quality)));
-			slotItem.setDurability(PotionColor.valueOf(recipe.getColor()).getColorId(canDistill()));
-		} else {
-			quality = 0;
-			removeEffects(potionMeta);
-			potionMeta.setDisplayName(P.p.color("&f" + P.p.languageReader.get("Brew_DistillUndefined")));
-			slotItem.setDurability(PotionColor.GREY.getColorId(canDistill()));
-		}
-
-		// Distill Lore
-		if (currentRecipe != null) {
-			if (colorInBrewer != hasColorLore(potionMeta)) {
-				convertLore(potionMeta, colorInBrewer);
-			}
-		}
-		String prefix = P.p.color("&7");
-		if (colorInBrewer && currentRecipe != null) {
-			prefix = getQualityColor(ingredients.getDistillQuality(recipe, distillRuns));
-		}
-		updateDistillLore(prefix, potionMeta);
-
-		slotItem.setItemMeta(potionMeta);
-	}
-
-	// Ageing Section ------------------
-
-	public void age(ItemStack item, float time, byte woodType) {
-		if (stat) {
-			return;
-		}
-
-		PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
-		ageTime += time;
-		
-		// if younger than half a day, it shouldnt get aged form
-		if (ageTime > 0.5) {
-			if (wood == 0) {
-				wood = woodType;
-			} else {
-				if (wood != woodType) {
-					woodShift(time, woodType);
-				}
-			}
-			BRecipe recipe = ingredients.getAgeRecipe(wood, ageTime, distillRuns > 0);
-			if (recipe != null) {
-				currentRecipe = recipe;
-				quality = calcQuality();
-
-				addOrReplaceEffects(potionMeta, getEffects(), quality);
-				potionMeta.setDisplayName(P.p.color("&f" + recipe.getName(quality)));
-				item.setDurability(PotionColor.valueOf(recipe.getColor()).getColorId(canDistill()));
-			} else {
-				quality = 0;
-				removeEffects(potionMeta);
-				potionMeta.setDisplayName(P.p.color("&f" + P.p.languageReader.get("Brew_BadPotion")));
-				item.setDurability(PotionColor.GREY.getColorId(canDistill()));
-			}
-		}
-
-		// Lore
-		if (currentRecipe != null) {
-			if (colorInBarrels != hasColorLore(potionMeta)) {
-				convertLore(potionMeta, colorInBarrels);
-			}
-		}
-		if (ageTime >= 1) {
-			String prefix = P.p.color("&7");
-			if (colorInBarrels && currentRecipe != null) {
-				prefix = getQualityColor(ingredients.getAgeQuality(currentRecipe, ageTime));
-			}
-			updateAgeLore(prefix, potionMeta);
-		}
-		if (ageTime > 0.5) {
-			if (colorInBarrels && !unlabeled && currentRecipe != null) {
-				updateWoodLore(potionMeta);
-			}
-		}
-		item.setItemMeta(potionMeta);
-	}
-
-	// Slowly shift the wood of the Brew to the new Type
-	public void woodShift(float time, byte to) {
-		byte factor = 1;
-		if (ageTime > 5) {
-			factor = 2;
-		} else if (ageTime > 10) {
-			factor = 2;
-			factor += Math.round(ageTime / 10);
-		}
-		if (wood > to) {
-			wood -= time / factor;
-			if (wood < to) {
-				wood = to;
-			}
-		} else {
-			wood += time / factor;
-			if (wood > to) {
-				wood = to;
-			}
-		}
-	}
-
-	// Lore -----------
-
-	// Converts to/from qualitycolored Lore
-	public void convertLore(PotionMeta meta, Boolean toQuality) {
-		if (currentRecipe == null) {
-			return;
-		}
-		meta.setLore(null);
-		int quality;
-		String prefix = P.p.color("&7");
-		String lore;
-
-		// Ingredients
-		if (toQuality && !unlabeled) {
-			quality = ingredients.getIngredientQuality(currentRecipe);
-			prefix = getQualityColor(quality);
-			lore = P.p.languageReader.get("Brew_Ingredients");
-			addOrReplaceLore(meta, prefix, lore);
-		}
-
-		// Cooking
-		if (toQuality && !unlabeled) {
-			if (distillRuns > 0 == currentRecipe.needsDistilling()) {
-				quality = ingredients.getCookingQuality(currentRecipe, distillRuns > 0);
-				prefix = getQualityColor(quality) + ingredients.getCookedTime() + " " + P.p.languageReader.get("Brew_minute");
-				if (ingredients.getCookedTime() > 1) {
-					prefix = prefix + P.p.languageReader.get("Brew_MinutePluralPostfix");
-				}
-				lore = " " + P.p.languageReader.get("Brew_fermented");
-				addOrReplaceLore(meta, prefix, lore);
-			}
-		}
-
-		// Distilling
-		if (distillRuns > 0) {
-			if (toQuality) {
-				quality = ingredients.getDistillQuality(currentRecipe, distillRuns);
-				prefix = getQualityColor(quality);
-			}
-			updateDistillLore(prefix, meta);
-		}
-
-		// Ageing
-		if (ageTime >= 1) {
-			if (toQuality) {
-				quality = ingredients.getAgeQuality(currentRecipe, ageTime);
-				prefix = getQualityColor(quality);
-			}
-			updateAgeLore(prefix, meta);
-		}
-
-		// WoodType
-		if (toQuality && !unlabeled) {
-			if (ageTime > 0.5) {
-				updateWoodLore(meta);
-			}
-		}
-	}
-
-	// sets the DistillLore. Prefix is the color to be used
-	public void updateDistillLore(String prefix, PotionMeta meta) {
-		if (!unlabeled) {
-			if (distillRuns > 1) {
-				prefix = prefix + distillRuns + P.p.languageReader.get("Brew_-times") + " ";
-			}
-		}
-		addOrReplaceLore(meta, prefix, P.p.languageReader.get("Brew_Distilled"));
-	}
-
-	// sets the AgeLore. Prefix is the color to be used
-	public void updateAgeLore(String prefix, PotionMeta meta) {
-		if (!unlabeled) {
-			if (ageTime >= 1 && ageTime < 2) {
-				prefix = prefix + P.p.languageReader.get("Brew_OneYear") + " ";
-			} else if (ageTime < 201) {
-				prefix = prefix + (int) Math.floor(ageTime) + " " + P.p.languageReader.get("Brew_Years") + " ";
-			} else {
-				prefix = prefix + P.p.languageReader.get("Brew_HundredsOfYears") + " ";
-			}
-		}
-		addOrReplaceLore(meta, prefix, P.p.languageReader.get("Brew_BarrelRiped"));
-	}
-
-	// updates/sets the color on WoodLore
-	public void updateWoodLore(PotionMeta meta) {
-		if (currentRecipe.getWood() > 0) {
-			int quality = ingredients.getWoodQuality(currentRecipe, wood);
-			addOrReplaceLore(meta, getQualityColor(quality), P.p.languageReader.get("Brew_Woodtype"));
-		} else {
-			if (meta.hasLore()) {
-				List<String> existingLore = meta.getLore();
-				int index = indexOfSubstring(existingLore, P.p.languageReader.get("Brew_Woodtype"));
-				if (index > -1) {
-					existingLore.remove(index);
-					meta.setLore(existingLore);
-				}
-			}
-		}
-	}
-
-	// Adds or replaces a line of Lore. Searches for Substring lore and replaces it
-	public static void addOrReplaceLore(PotionMeta meta, String prefix, String lore) {
-		if (meta.hasLore()) {
-			List<String> existingLore = meta.getLore();
-			int index = indexOfSubstring(existingLore, lore);
-			if (index > -1) {
-				existingLore.set(index, prefix + lore);
-			} else {
-				existingLore.add(prefix + lore);
-			}
-			meta.setLore(existingLore);
-			return;
-		}
-		List<String> newLore = new ArrayList<String>();
-		newLore.add("");
-		newLore.add(prefix + lore);
-		meta.setLore(newLore);
-	}
-
-	// Adds the Effect names to the Items description
-	public static void addOrReplaceEffects(PotionMeta meta, ArrayList<BEffect> effects, int quality) {
-		if (effects != null) {
-			for (BEffect effect : effects) {
-				if (!effect.isHidden()) {
-					effect.writeInto(meta, quality);
-				}
-			}
-		}
-	}
-
-	// Removes all effects except regeneration which stores data
-	public static void removeEffects(PotionMeta meta) {
-		if (meta.hasCustomEffects()) {
-			for (PotionEffect effect : meta.getCustomEffects()) {
-				PotionEffectType type = effect.getType();
-				if (!type.equals(PotionEffectType.REGENERATION)) {
-					meta.removeCustomEffect(type);
-				}
-			}
-		}
-	}
-
-	// Returns the Index of a String from the list that contains this substring
-	public static int indexOfSubstring(List<String> list, String substring) {
-		for (int index = 0; index < list.size(); index++) {
-			String string = list.get(index);
-			if (string.contains(substring)) {
-				return index;
-			}
-		}
-		return -1;
-	}
-
-	// True if the PotionMeta has colored Lore
-	public  static Boolean hasColorLore(PotionMeta meta) {
-		return meta.hasLore() && !meta.getLore().get(1).startsWith(P.p.color("&7"));
-	}
-
-	// gets the Color that represents a quality in Lore
-	public static String getQualityColor(int quality) {
-		String color;
-		if (quality > 8) {
-			color = "&a";
-		} else if (quality > 6) {
-			color = "&e";
-		} else if (quality > 4) {
-			color = "&6";
-		} else if (quality > 2) {
-			color = "&c";
-		} else {
-			color = "&4";
-		}
-		return P.p.color(color);
-	}
-
-	// Saves all data
-	public static void save(ConfigurationSection config) {
-		for (Map.Entry<Integer, Brew> entry : potions.entrySet()) {
-			int uid = entry.getKey();
-			Brew brew = entry.getValue();
-			ConfigurationSection idConfig = config.createSection("" + uid);
-			// not saving unneccessary data
-			if (brew.quality != 0) {
-				idConfig.set("quality", brew.quality);
-			}
-			if (brew.distillRuns != 0) {
-				idConfig.set("distillRuns", brew.distillRuns);
-			}
-			if (brew.ageTime != 0) {
-				idConfig.set("ageTime", brew.ageTime);
-			}
-			if (brew.wood != -1) {
-				idConfig.set("wood", brew.wood);
-			}
-			if (brew.currentRecipe != null) {
-				idConfig.set("recipe", brew.currentRecipe.getName(5));
-			}
-			if (brew.unlabeled) {
-				idConfig.set("unlabeled", true);
-			}
-			if (brew.persistent) {
-				idConfig.set("persist", true);
-			}
-			if (brew.stat) {
-				idConfig.set("stat", true);
-			}
-			// save the ingredients
-			idConfig.set("ingId", brew.ingredients.save(config.getParent()));
-		}
-	}
-
-	public static enum PotionColor {
-		PINK(1),
-		CYAN(2),
-		ORANGE(3),
-		GREEN(4),
-		BRIGHT_RED(5),
-		BLUE(6),
-		BLACK(8),
-		RED(9),
-		GREY(10),
-		WATER(11),
-		DARK_RED(12),
-		BRIGHT_GREY(14);
-
-		private final int colorId;
-
-		private PotionColor(int colorId) {
-			this.colorId = colorId;
-		}
-
-		// gets the Damage Value, that sets a color on the potion
-		// offset +32 is not accepted by brewer, so not further destillable
-		public short getColorId(boolean destillable) {
-			if (destillable) {
-				return (short) (colorId + 64);
-			}
-			return (short) (colorId + 32);
-		}
-	}
+    // represents the liquid in the brewed Potions
+    public static Map<Integer, Brew> potions = new HashMap<Integer, Brew>();
+    public static Boolean colorInBarrels; // color the Lore while in Barrels
+    public static Boolean colorInBrewer; // color the Lore while in Brewer
+
+    private BIngredients ingredients;
+    private int quality;
+    private int distillRuns;
+    private float ageTime;
+    private float wood;
+    private BRecipe currentRecipe;
+    private boolean unlabeled;
+    private boolean persistent;
+    private boolean stat; // static potions should not be changed
+
+    public Brew(int uid, BIngredients ingredients) {
+        this.ingredients = ingredients;
+        potions.put(uid, this);
+    }
+
+    // quality already set
+    public Brew(int uid, int quality, BRecipe recipe, BIngredients ingredients) {
+        this.ingredients = ingredients;
+        this.quality = quality;
+        this.currentRecipe = recipe;
+        potions.put(uid, this);
+    }
+
+    // loading from file
+    public Brew(int uid, BIngredients ingredients, int quality, int distillRuns, float ageTime, float wood, String recipe, boolean unlabeled, boolean persistent, boolean stat) {
+        potions.put(uid, this);
+        this.ingredients = ingredients;
+        this.quality = quality;
+        this.distillRuns = distillRuns;
+        this.ageTime = ageTime;
+        this.wood = wood;
+        this.unlabeled = unlabeled;
+        this.persistent = persistent;
+        this.stat = stat;
+        setRecipeFromString(recipe);
+    }
+
+    // returns a Brew by its UID
+    public static Brew get(int uid) {
+        if (uid < -1) {
+            if (!potions.containsKey(uid)) {
+                P.p.errorLog("Database failure! unable to find UID " + uid + " of a custom Potion!");
+                return null;// throw some exception?
+            }
+        } else {
+            return null;
+        }
+        return potions.get(uid);
+    }
+
+    // returns a Brew by PotionMeta
+    public static Brew get(PotionMeta meta) {
+        return get(getUID(meta));
+    }
+
+    // returns a Brew by ItemStack
+    public static Brew get(ItemStack item) {
+        if (item.getType() == Material.POTION) {
+            if (item.hasItemMeta()) {
+                PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
+                return get(potionMeta);
+            }
+        }
+        return null;
+    }
+
+    // returns UID of custom Potion item
+    public static int getUID(ItemStack item) {
+        return getUID((PotionMeta) item.getItemMeta());
+    }
+
+    // returns UID of custom Potion meta
+    public static int getUID(PotionMeta potionMeta) {
+        if (potionMeta.hasCustomEffect(PotionEffectType.REGENERATION)) {
+            for (PotionEffect effect : potionMeta.getCustomEffects()) {
+                if (effect.getType().equals(PotionEffectType.REGENERATION)) {
+                    if (effect.getDuration() < -1) {
+                        return effect.getDuration();
+                    }
+                }
+            }
+        }
+        return 0;
+    }
+
+    // generate an UID
+    public static int generateUID() {
+        int uid = -2;
+        while (potions.containsKey(uid)) {
+            uid -= 1;
+        }
+        return uid;
+    }
+
+    //returns the recipe with the given name, recalculates if not found
+    public boolean setRecipeFromString(String name) {
+        currentRecipe = null;
+        if (name != null && !name.equals("")) {
+            for (BRecipe recipe : BIngredients.recipes) {
+                if (recipe.getName(5).equalsIgnoreCase(name)) {
+                    currentRecipe = recipe;
+                    return true;
+                }
+            }
+
+            if (quality > 0) {
+                currentRecipe = ingredients.getBestRecipe(wood, ageTime, distillRuns > 0);
+                if (currentRecipe != null) {
+                    if (!stat) {
+                        this.quality = calcQuality();
+                    }
+                    P.p.log("Brew was made from Recipe: '" + name + "' which could not be found. '" + currentRecipe.getName(5) + "' used instead!");
+                    return true;
+                } else {
+                    P.p.errorLog("Brew was made from Recipe: '" + name + "' which could not be found!");
+                }
+            }
+        }
+        return false;
+    }
+
+    public boolean reloadRecipe() {
+        if (currentRecipe != null) {
+            return setRecipeFromString(currentRecipe.getName(5));
+        }
+        return true;
+    }
+
+    // Copy a Brew with a new unique ID and return its item
+    public ItemStack copy(ItemStack item) {
+        ItemStack copy = item.clone();
+        int uid = generateUID();
+        clone(uid);
+        PotionMeta meta = (PotionMeta) copy.getItemMeta();
+        meta.addCustomEffect((PotionEffectType.REGENERATION).createEffect((uid * 4), 0), true);
+        copy.setItemMeta(meta);
+        return copy;
+    }
+
+    // Clones this instance with a new unique ID
+    public Brew clone(int uid) {
+        Brew brew = new Brew(uid, quality, currentRecipe, ingredients);
+        brew.distillRuns = distillRuns;
+        brew.ageTime = ageTime;
+        brew.unlabeled = unlabeled;
+        if (!brew.persistent) {
+            brew.stat = stat;
+        }
+        return brew;
+    }
+
+    // remove potion from file (drinking, despawning, combusting, cmdDeleting, should be more!)
+    public void remove(ItemStack item) {
+        if (!persistent) {
+            potions.remove(getUID(item));
+        }
+    }
+
+    // calculate alcohol from recipe
+    public int calcAlcohol() {
+        if (quality == 0) {
+            // Give bad potions some alc
+            int badAlc = 0;
+            if (distillRuns > 1) {
+                badAlc = distillRuns;
+            }
+            if (ageTime > 10) {
+                badAlc += 5;
+            } else if (ageTime > 2) {
+                badAlc += 3;
+            }
+            if (currentRecipe != null) {
+                return badAlc;
+            } else {
+                return badAlc / 2;
+            }
+        }
+
+        if (currentRecipe != null) {
+            int alc = currentRecipe.getAlcohol();
+            if (currentRecipe.needsDistilling()) {
+                if (distillRuns == 0) {
+                    return 0;
+                }
+                // bad quality can decrease alc by up to 40%
+                alc *= 1 - ((float) (10 - quality) * 0.04);
+                // distillable Potions should have half alc after one and full alc after all needed distills
+                alc /= 2;
+                alc *= 1.0F + ((float) distillRuns / currentRecipe.getDistillRuns());
+            } else {
+                // quality decides 10% - 100%
+                alc *= ((float) quality / 10.0);
+            }
+            if (alc > 0) {
+                return alc;
+            }
+        }
+        return 0;
+    }
+
+    // calculating quality
+    public int calcQuality() {
+        // calculate quality from all of the factors
+        float quality = ingredients.getIngredientQuality(currentRecipe) + ingredients.getCookingQuality(currentRecipe, distillRuns > 0);
+        if (currentRecipe.needsToAge() || ageTime > 0.5) {
+            quality += ingredients.getWoodQuality(currentRecipe, wood) + ingredients.getAgeQuality(currentRecipe, ageTime);
+            quality /= 4;
+        } else {
+            quality /= 2;
+        }
+        return Math.round(quality);
+    }
+
+    public int getQuality() {
+        return quality;
+    }
+
+    public boolean canDistill() {
+        if (currentRecipe != null) {
+            return currentRecipe.getDistillRuns() > distillRuns;
+        } else if (distillRuns >= 6) {
+            return false;
+        }
+        return true;
+    }
+
+    // return special effect
+    public ArrayList<BEffect> getEffects() {
+        if (currentRecipe != null && quality > 0) {
+            return currentRecipe.getEffects();
+        }
+        return null;
+    }
+
+    // Set unlabeled to true to hide the numbers in Lore
+    public void unLabel(ItemStack item) {
+        PotionMeta meta = (PotionMeta) item.getItemMeta();
+        if (meta.hasLore()) {
+            if (distillRuns > 0) {
+                addOrReplaceLore(meta, P.p.color("&7"), P.p.languageReader.get("Brew_Distilled"));
+            }
+            if (ageTime >= 1) {
+                addOrReplaceLore(meta, P.p.color("&7"), P.p.languageReader.get("Brew_BarrelRiped"));
+            }
+            item.setItemMeta(meta);
+        }
+        unlabeled = true;
+    }
+
+    public boolean isPersistent() {
+        return persistent;
+    }
+
+    // Make a potion persistent to not delete it when drinking it
+    public void makePersistent() {
+        persistent = true;
+    }
+
+    // Remove the Persistence Flag from a brew, so it will be normally deleted when drinking it
+    public void removePersistence() {
+        persistent = false;
+    }
+
+    public boolean isStatic() {
+        return stat;
+    }
+
+    // Set the Static flag, so potion is unchangeable
+    public void setStatic(boolean stat, ItemStack potion) {
+        this.stat = stat;
+        if (currentRecipe != null && canDistill()) {
+            if (stat) {
+                if (P.use1_9) {
+                    PotionMeta potionMeta = (PotionMeta) potion.getItemMeta();
+                    potionMeta.setMainEffect(PotionColor.valueOf(currentRecipe.getColor()).getEffect());
+                } else {
+                    potion.setDurability(PotionColor.valueOf(currentRecipe.getColor()).getColorId(false));
+                }
+            } else if (P.use1_9) {
+                PotionMeta potionMeta = (PotionMeta) potion.getItemMeta();
+                potionMeta.setMainEffect(PotionColor.valueOf(currentRecipe.getColor()).getEffect());
+            } else {
+                potion.setDurability(PotionColor.valueOf(currentRecipe.getColor()).getColorId(true));
+            }
+        }
+    }
+
+    // Distilling section ---------------
+    // distill all custom potions in the brewer
+    public static void distillAll(BrewerInventory inv, Boolean[] contents) {
+        int slot = 0;
+        while (slot < 3) {
+            if (contents[slot]) {
+                ItemStack slotItem = inv.getItem(slot);
+                PotionMeta potionMeta = (PotionMeta) slotItem.getItemMeta();
+                Brew brew = get(potionMeta);
+                brew.distillSlot(slotItem, potionMeta);
+            }
+            slot++;
+        }
+    }
+
+    // distill custom potion in given slot
+    public void distillSlot(ItemStack slotItem, PotionMeta potionMeta) {
+        if (stat) {
+            return;
+        }
+
+        distillRuns += 1;
+        BRecipe recipe = ingredients.getdistillRecipe(wood, ageTime);
+        if (recipe != null) {
+            // distillRuns will have an effect on the amount of alcohol, not the quality
+            currentRecipe = recipe;
+            quality = calcQuality();
+
+            addOrReplaceEffects(potionMeta, getEffects(), quality);
+            potionMeta.setDisplayName(P.p.color("&f" + recipe.getName(quality)));
+            if (P.use1_9) {
+                potionMeta.setMainEffect(PotionColor.valueOf(recipe.getColor()).getEffect());
+            } else {
+                slotItem.setDurability(PotionColor.valueOf(recipe.getColor()).getColorId(canDistill()));
+            }
+
+        } else {
+            quality = 0;
+            removeEffects(potionMeta);
+            potionMeta.setDisplayName(P.p.color("&f" + P.p.languageReader.get("Brew_DistillUndefined")));
+            if (P.use1_9) {
+                potionMeta.setMainEffect(PotionColor.GREY.getEffect());
+            } else {
+                slotItem.setDurability(PotionColor.GREY.getColorId(canDistill()));
+            }
+        }
+
+        // Distill Lore
+        if (currentRecipe != null) {
+            if (colorInBrewer != hasColorLore(potionMeta)) {
+                convertLore(potionMeta, colorInBrewer);
+            }
+        }
+        String prefix = P.p.color("&7");
+        if (colorInBrewer && currentRecipe != null) {
+            prefix = getQualityColor(ingredients.getDistillQuality(recipe, distillRuns));
+        }
+        updateDistillLore(prefix, potionMeta);
+
+        slotItem.setItemMeta(potionMeta);
+    }
+
+    // Ageing Section ------------------
+    public void age(ItemStack item, float time, byte woodType) {
+        if (stat) {
+            return;
+        }
+
+        PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
+        ageTime += time;
+
+        // if younger than half a day, it shouldnt get aged form
+        if (ageTime > 0.5) {
+            if (wood == 0) {
+                wood = woodType;
+            } else if (wood != woodType) {
+                woodShift(time, woodType);
+            }
+            BRecipe recipe = ingredients.getAgeRecipe(wood, ageTime, distillRuns > 0);
+            if (recipe != null) {
+                currentRecipe = recipe;
+                quality = calcQuality();
+
+                addOrReplaceEffects(potionMeta, getEffects(), quality);
+                potionMeta.setDisplayName(P.p.color("&f" + recipe.getName(quality)));
+                if (P.use1_9) {
+                    potionMeta.setMainEffect(PotionColor.valueOf(recipe.getColor()).getEffect());
+                } else {
+                    item.setDurability(PotionColor.valueOf(recipe.getColor()).getColorId(canDistill()));
+                }
+            } else {
+                quality = 0;
+                removeEffects(potionMeta);
+                potionMeta.setDisplayName(P.p.color("&f" + P.p.languageReader.get("Brew_BadPotion")));
+                if (P.use1_9) {
+                    potionMeta.setMainEffect(PotionColor.GREY.getEffect());
+                } else {
+                    item.setDurability(PotionColor.GREY.getColorId(canDistill()));
+                }
+            }
+        }
+
+        // Lore
+        if (currentRecipe != null) {
+            if (colorInBarrels != hasColorLore(potionMeta)) {
+                convertLore(potionMeta, colorInBarrels);
+            }
+        }
+        if (ageTime >= 1) {
+            String prefix = P.p.color("&7");
+            if (colorInBarrels && currentRecipe != null) {
+                prefix = getQualityColor(ingredients.getAgeQuality(currentRecipe, ageTime));
+            }
+            updateAgeLore(prefix, potionMeta);
+        }
+        if (ageTime > 0.5) {
+            if (colorInBarrels && !unlabeled && currentRecipe != null) {
+                updateWoodLore(potionMeta);
+            }
+        }
+        item.setItemMeta(potionMeta);
+    }
+
+    // Slowly shift the wood of the Brew to the new Type
+    public void woodShift(float time, byte to) {
+        byte factor = 1;
+        if (ageTime > 5) {
+            factor = 2;
+        } else if (ageTime > 10) {
+            factor = 2;
+            factor += Math.round(ageTime / 10);
+        }
+        if (wood > to) {
+            wood -= time / factor;
+            if (wood < to) {
+                wood = to;
+            }
+        } else {
+            wood += time / factor;
+            if (wood > to) {
+                wood = to;
+            }
+        }
+    }
+
+    // Lore -----------
+    // Converts to/from qualitycolored Lore
+    public void convertLore(PotionMeta meta, Boolean toQuality) {
+        if (currentRecipe == null) {
+            return;
+        }
+        meta.setLore(null);
+        int quality;
+        String prefix = P.p.color("&7");
+        String lore;
+
+        // Ingredients
+        if (toQuality && !unlabeled) {
+            quality = ingredients.getIngredientQuality(currentRecipe);
+            prefix = getQualityColor(quality);
+            lore = P.p.languageReader.get("Brew_Ingredients");
+            addOrReplaceLore(meta, prefix, lore);
+        }
+
+        // Cooking
+        if (toQuality && !unlabeled) {
+            if (distillRuns > 0 == currentRecipe.needsDistilling()) {
+                quality = ingredients.getCookingQuality(currentRecipe, distillRuns > 0);
+                prefix = getQualityColor(quality) + ingredients.getCookedTime() + " " + P.p.languageReader.get("Brew_minute");
+                if (ingredients.getCookedTime() > 1) {
+                    prefix = prefix + P.p.languageReader.get("Brew_MinutePluralPostfix");
+                }
+                lore = " " + P.p.languageReader.get("Brew_fermented");
+                addOrReplaceLore(meta, prefix, lore);
+            }
+        }
+
+        // Distilling
+        if (distillRuns > 0) {
+            if (toQuality) {
+                quality = ingredients.getDistillQuality(currentRecipe, distillRuns);
+                prefix = getQualityColor(quality);
+            }
+            updateDistillLore(prefix, meta);
+        }
+
+        // Ageing
+        if (ageTime >= 1) {
+            if (toQuality) {
+                quality = ingredients.getAgeQuality(currentRecipe, ageTime);
+                prefix = getQualityColor(quality);
+            }
+            updateAgeLore(prefix, meta);
+        }
+
+        // WoodType
+        if (toQuality && !unlabeled) {
+            if (ageTime > 0.5) {
+                updateWoodLore(meta);
+            }
+        }
+    }
+
+    // sets the DistillLore. Prefix is the color to be used
+    public void updateDistillLore(String prefix, PotionMeta meta) {
+        if (!unlabeled) {
+            if (distillRuns > 1) {
+                prefix = prefix + distillRuns + P.p.languageReader.get("Brew_-times") + " ";
+            }
+        }
+        addOrReplaceLore(meta, prefix, P.p.languageReader.get("Brew_Distilled"));
+    }
+
+    // sets the AgeLore. Prefix is the color to be used
+    public void updateAgeLore(String prefix, PotionMeta meta) {
+        if (!unlabeled) {
+            if (ageTime >= 1 && ageTime < 2) {
+                prefix = prefix + P.p.languageReader.get("Brew_OneYear") + " ";
+            } else if (ageTime < 201) {
+                prefix = prefix + (int) Math.floor(ageTime) + " " + P.p.languageReader.get("Brew_Years") + " ";
+            } else {
+                prefix = prefix + P.p.languageReader.get("Brew_HundredsOfYears") + " ";
+            }
+        }
+        addOrReplaceLore(meta, prefix, P.p.languageReader.get("Brew_BarrelRiped"));
+    }
+
+    // updates/sets the color on WoodLore
+    public void updateWoodLore(PotionMeta meta) {
+        if (currentRecipe.getWood() > 0) {
+            int quality = ingredients.getWoodQuality(currentRecipe, wood);
+            addOrReplaceLore(meta, getQualityColor(quality), P.p.languageReader.get("Brew_Woodtype"));
+        } else if (meta.hasLore()) {
+            List<String> existingLore = meta.getLore();
+            int index = indexOfSubstring(existingLore, P.p.languageReader.get("Brew_Woodtype"));
+            if (index > -1) {
+                existingLore.remove(index);
+                meta.setLore(existingLore);
+            }
+        }
+    }
+
+    // Adds or replaces a line of Lore. Searches for Substring lore and replaces it
+    public static void addOrReplaceLore(PotionMeta meta, String prefix, String lore) {
+        if (meta.hasLore()) {
+            List<String> existingLore = meta.getLore();
+            int index = indexOfSubstring(existingLore, lore);
+            if (index > -1) {
+                existingLore.set(index, prefix + lore);
+            } else {
+                existingLore.add(prefix + lore);
+            }
+            meta.setLore(existingLore);
+            return;
+        }
+        List<String> newLore = new ArrayList<String>();
+        newLore.add("");
+        newLore.add(prefix + lore);
+        meta.setLore(newLore);
+    }
+
+    // Adds the Effect names to the Items description
+    public static void addOrReplaceEffects(PotionMeta meta, ArrayList<BEffect> effects, int quality) {
+        if (effects != null) {
+            for (BEffect effect : effects) {
+                if (!effect.isHidden()) {
+                    effect.writeInto(meta, quality);
+                }
+            }
+        }
+    }
+
+    // Removes all effects except regeneration which stores data
+    public static void removeEffects(PotionMeta meta) {
+        if (meta.hasCustomEffects()) {
+            for (PotionEffect effect : meta.getCustomEffects()) {
+                PotionEffectType type = effect.getType();
+                if (!type.equals(PotionEffectType.REGENERATION)) {
+                    meta.removeCustomEffect(type);
+                }
+            }
+        }
+    }
+
+    // Returns the Index of a String from the list that contains this substring
+    public static int indexOfSubstring(List<String> list, String substring) {
+        for (int index = 0; index < list.size(); index++) {
+            String string = list.get(index);
+            if (string.contains(substring)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    // True if the PotionMeta has colored Lore
+    public static Boolean hasColorLore(PotionMeta meta) {
+        return meta.hasLore() && !meta.getLore().get(1).startsWith(P.p.color("&7"));
+    }
+
+    // gets the Color that represents a quality in Lore
+    public static String getQualityColor(int quality) {
+        String color;
+        if (quality > 8) {
+            color = "&a";
+        } else if (quality > 6) {
+            color = "&e";
+        } else if (quality > 4) {
+            color = "&6";
+        } else if (quality > 2) {
+            color = "&c";
+        } else {
+            color = "&4";
+        }
+        return P.p.color(color);
+    }
+
+    // Saves all data
+    public static void save(ConfigurationSection config) {
+        for (Map.Entry<Integer, Brew> entry : potions.entrySet()) {
+            int uid = entry.getKey();
+            Brew brew = entry.getValue();
+            ConfigurationSection idConfig = config.createSection("" + uid);
+            // not saving unneccessary data
+            if (brew.quality != 0) {
+                idConfig.set("quality", brew.quality);
+            }
+            if (brew.distillRuns != 0) {
+                idConfig.set("distillRuns", brew.distillRuns);
+            }
+            if (brew.ageTime != 0) {
+                idConfig.set("ageTime", brew.ageTime);
+            }
+            if (brew.wood != -1) {
+                idConfig.set("wood", brew.wood);
+            }
+            if (brew.currentRecipe != null) {
+                idConfig.set("recipe", brew.currentRecipe.getName(5));
+            }
+            if (brew.unlabeled) {
+                idConfig.set("unlabeled", true);
+            }
+            if (brew.persistent) {
+                idConfig.set("persist", true);
+            }
+            if (brew.stat) {
+                idConfig.set("stat", true);
+            }
+            // save the ingredients
+            idConfig.set("ingId", brew.ingredients.save(config.getParent()));
+        }
+    }
+
+    public static enum PotionColor {
+        PINK(1, PotionEffectType.REGENERATION),
+        CYAN(2, PotionEffectType.SPEED),
+        ORANGE(3, PotionEffectType.FIRE_RESISTANCE),
+        GREEN(4, PotionEffectType.POISON),
+        BRIGHT_RED(5, PotionEffectType.HEAL),
+        BLUE(6, PotionEffectType.NIGHT_VISION),
+        BLACK(8, PotionEffectType.WEAKNESS),
+        RED(9, PotionEffectType.INCREASE_DAMAGE),
+        GREY(10, PotionEffectType.SLOW),
+        WATER(11, PotionEffectType.WATER_BREATHING),
+        DARK_RED(12, PotionEffectType.HARM),
+        BRIGHT_GREY(14, PotionEffectType.INVISIBILITY);
+
+        private final int colorId;
+        private final PotionEffectType effect;
+
+        private PotionColor(int colorId, PotionEffectType effect) {
+            this.colorId = colorId;
+            this.effect = effect;
+        }
+
+        // gets the Damage Value, that sets a color on the potion
+        // offset +32 is not accepted by brewer, so not further destillable
+        public short getColorId(boolean destillable) {
+            if (destillable) {
+                return (short) (colorId + 64);
+            }
+            return (short) (colorId + 32);
+        }
+
+        public PotionEffectType getEffect() {
+            return effect;
+        }
+
+    }
 
 }

--- a/src/com/dre/brewery/P.java
+++ b/src/com/dre/brewery/P.java
@@ -1,46 +1,44 @@
 package com.dre.brewery;
 
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Map;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.ListIterator;
-import java.util.HashMap;
-import java.io.IOException;
-import java.io.File;
-import java.util.UUID;
-
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.configuration.ConfigurationSection;
-
+import com.dre.brewery.filedata.*;
+import com.dre.brewery.integration.LogBlockBarrel;
 import com.dre.brewery.integration.WGBarrel;
 import com.dre.brewery.integration.WGBarrelNew;
 import com.dre.brewery.integration.WGBarrelOld;
-import org.apache.commons.lang.math.NumberUtils;
-import org.bukkit.event.HandlerList;
-import org.bukkit.Bukkit;
-import org.bukkit.World;
-import org.bukkit.Location;
-import org.bukkit.command.CommandSender;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-
 import com.dre.brewery.listeners.*;
-import com.dre.brewery.filedata.*;
-import com.dre.brewery.integration.LogBlockBarrel;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.lang.math.NumberUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public class P extends JavaPlugin {
 	public static P p;
 	public static String configVersion = "1.3.1";
 	public static boolean debug;
 	public static boolean useUUID;
+        public static boolean use1_9;
 	public static boolean updateCheck;
 
 	// Third Party Enabled
@@ -57,6 +55,7 @@ public class P extends JavaPlugin {
 	public EntityListener entityListener;
 	public InventoryListener inventoryListener;
 	public WorldListener worldListener;
+        public Compat1_9 compat1_9;
 
 	// Language
 	public String language;
@@ -68,7 +67,12 @@ public class P extends JavaPlugin {
 
 		// Version check
 		String v = Bukkit.getBukkitVersion();
-		useUUID = !v.matches(".*1\\.[1-6].*") && !v.matches(".*1\\.7\\.[0-5].*");
+		useUUID = !v.matches(".*1\\.[0-6].*") && !v.matches(".*1\\.7\\.[0-5].*");
+                use1_9 = !v.matches(".*1\\.[0-8].*");
+                if (use1_9) {
+                    log("&cExperimental support for Bukkit 1.9 enabled.");
+                    log("&cPlease note that the changes of 1.9 make a build of Brewery with the same quality as for older versions impossible.");
+                }
 
 		// load the Config
 		try {
@@ -94,6 +98,7 @@ public class P extends JavaPlugin {
 		entityListener = new EntityListener();
 		inventoryListener = new InventoryListener();
 		worldListener = new WorldListener();
+                compat1_9 = new Compat1_9();
 		getCommand("Brewery").setExecutor(new CommandListener());
 
 		p.getServer().getPluginManager().registerEvents(blockListener, p);
@@ -101,6 +106,9 @@ public class P extends JavaPlugin {
 		p.getServer().getPluginManager().registerEvents(entityListener, p);
 		p.getServer().getPluginManager().registerEvents(inventoryListener, p);
 		p.getServer().getPluginManager().registerEvents(worldListener, p);
+                if (use1_9) {
+                    p.getServer().getPluginManager().registerEvents(compat1_9, p);
+                }
 
 		// Heartbeat
 		p.getServer().getScheduler().runTaskTimer(p, new BreweryRunnable(), 650, 1200);

--- a/src/com/dre/brewery/listeners/Compat1_9.java
+++ b/src/com/dre/brewery/listeners/Compat1_9.java
@@ -1,0 +1,31 @@
+package com.dre.brewery.listeners;
+
+import com.dre.brewery.Brew;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
+
+// Workaround to remove unwanted potion effects
+public class Compat1_9 implements Listener {
+
+    @EventHandler
+    public void onPlayerDrink(PlayerItemConsumeEvent event) {
+        ItemStack item = event.getItem();
+        Brew brew = Brew.get(item);
+        if (brew == null) {
+            return;
+        }
+
+        if (item.getType() == Material.POTION) {
+            try {
+                PotionMeta meta = (PotionMeta) item.getItemMeta();
+                meta.setMainEffect(null);
+                item.setItemMeta(meta);
+            } catch (Exception exception) {}
+        }
+    }
+
+}


### PR DESCRIPTION
Changelog:
* Removed ManagerXL (discontinued)
* Updated to GriefPrevention 13.9.1
* Changed PotionColor identifier to PotionEffectTypes (probably not 100% correct and incomplete; needs testing)
* Added a listener (only registered if version is >= 1.9) to remove the unwanted main potion effect (the desired effects should be CustomPotionEffects) when a player drinks a brew. Seems to work, even though there are errors. Subject to improve...
* Version check for 1.9 to ensure backwards compatibility

Not ready to merge, yet!