### PR TITLE
Add Fawe support

### DIFF
--- a/src/com/dre/brewery/P.java
+++ b/src/com/dre/brewery/P.java
@@ -273,7 +273,7 @@ public class P extends JavaPlugin {
 			Plugin plugin = Bukkit.getPluginManager().getPlugin("WorldEdit");
 			if (plugin != null) {
 				String wgv = plugin.getDescription().getVersion();
-				if (wgv.startsWith("7.")) wg = new WGBarrel7();
+				if (wgv.startsWith("7.") || Bukkit.getPluginManager().getPlugin("FastAsyncWorldEdit") != null) wg = new WGBarrel7();
 				else if (wgv.startsWith("6.")) wg = new WGBarrelNew();
 				else if (wgv.startsWith("5.")) wg = new WGBarrelOld();
 			}

--- a/src/com/dre/brewery/P.java
+++ b/src/com/dre/brewery/P.java
@@ -273,7 +273,7 @@ public class P extends JavaPlugin {
 			Plugin plugin = Bukkit.getPluginManager().getPlugin("WorldEdit");
 			if (plugin != null) {
 				String wgv = plugin.getDescription().getVersion();
-				if (wgv.startsWith("7.") || Bukkit.getPluginManager().getPlugin("FastAsyncWorldEdit") != null) wg = new WGBarrel7();
+				if (wgv.startsWith("7.") || (Bukkit.getPluginManager().getPlugin("FastAsyncWorldEdit") != null && use1_13)) wg = new WGBarrel7();
 				else if (wgv.startsWith("6.")) wg = new WGBarrelNew();
 				else if (wgv.startsWith("5.")) wg = new WGBarrelOld();
 			}


### PR DESCRIPTION
Since FastAsyncWorldEdit set the WorldEdit version to "unspecified" in 1.13. Brewery fail to set up the right WGBarrel. With this little extension Brewery checks if Fawe is used, and load the right WGBarrel.