### PR TITLE
Add RGB colored potions

### DIFF
--- a/src/com/dre/brewery/BIngredients.java
+++ b/src/com/dre/brewery/BIngredients.java
@@ -80,7 +80,7 @@ public class BIngredients {
 			Brew.addOrReplaceEffects(potionMeta, brew.getEffects(), brew.getQuality());
 
 			cookedName = cookRecipe.getName(quality);
-			Brew.PotionColor.valueOf(cookRecipe.getColor()).colorBrew(potionMeta, potion, false);
+			Brew.PotionColor.fromString(cookRecipe.getColor()).colorBrew(potionMeta, potion, false);
 
 		} else {
 			// new base potion

--- a/src/com/dre/brewery/BRecipe.java
+++ b/src/com/dre/brewery/BRecipe.java
@@ -146,7 +146,7 @@ public class BRecipe {
 			return false;
 		}
 		try {
-			Brew.PotionColor.valueOf(getColor());
+			Brew.PotionColor.fromString(getColor());
 		} catch (IllegalArgumentException e) {
 			P.p.errorLog("Invalid Color '" + color + "' in Recipe: " + getName(5));
 			return false;
@@ -263,7 +263,7 @@ public class BRecipe {
 
 		Brew brew = new Brew(uid, bIngredients, quality, distillruns, getAge(), wood, getName(5), false, false, true, 0);
 
-		Brew.PotionColor.valueOf(getColor()).colorBrew(potionMeta, potion, false);
+		Brew.PotionColor.fromString(getColor()).colorBrew(potionMeta, potion, false);
 		potionMeta.setDisplayName(P.p.color("&f" + getName(quality)));
 		// This effect stores the UID in its Duration
 		potionMeta.addCustomEffect((PotionEffectType.REGENERATION).createEffect((uid * 4), 0), true);

--- a/src/com/dre/brewery/Brew.java
+++ b/src/com/dre/brewery/Brew.java
@@ -710,7 +710,7 @@ public class Brew {
 
 		public PotionColor(Color color) {
 			colorId = -1;
-			type = null;
+			type = WATER.getType();
 			this.color = color;
 		}
 

--- a/src/com/dre/brewery/Brew.java
+++ b/src/com/dre/brewery/Brew.java
@@ -315,9 +315,9 @@ public class Brew {
 		this.stat = stat;
 		if (currentRecipe != null && canDistill()) {
 			if (stat) {
-				PotionColor.valueOf(currentRecipe.getColor()).colorBrew(((PotionMeta) potion.getItemMeta()), potion, false);
+				PotionColor.fromString(currentRecipe.getColor()).colorBrew(((PotionMeta) potion.getItemMeta()), potion, false);
 			} else {
-				PotionColor.valueOf(currentRecipe.getColor()).colorBrew(((PotionMeta) potion.getItemMeta()), potion, true);
+				PotionColor.fromString(currentRecipe.getColor()).colorBrew(((PotionMeta) potion.getItemMeta()), potion, true);
 			}
 		}
 	}
@@ -354,7 +354,7 @@ public class Brew {
 
 			addOrReplaceEffects(potionMeta, getEffects(), quality);
 			potionMeta.setDisplayName(P.p.color("&f" + recipe.getName(quality)));
-			PotionColor.valueOf(recipe.getColor()).colorBrew(potionMeta, slotItem, canDistill());
+			PotionColor.fromString(recipe.getColor()).colorBrew(potionMeta, slotItem, canDistill());
 
 		} else {
 			quality = 0;
@@ -419,7 +419,7 @@ public class Brew {
 
 				addOrReplaceEffects(potionMeta, getEffects(), quality);
 				potionMeta.setDisplayName(P.p.color("&f" + recipe.getName(quality)));
-				PotionColor.valueOf(recipe.getColor()).colorBrew(potionMeta, item, canDistill());
+				PotionColor.fromString(recipe.getColor()).colorBrew(potionMeta, item, canDistill());
 			} else {
 				quality = 0;
 				removeEffects(potionMeta);
@@ -684,19 +684,19 @@ public class Brew {
 		}
 	}
 
-	public enum PotionColor {
-		PINK(1, PotionType.REGEN, Color.FUCHSIA),
-		CYAN(2, PotionType.SPEED, Color.AQUA),
-		ORANGE(3, PotionType.FIRE_RESISTANCE, Color.ORANGE),
-		GREEN(4, PotionType.POISON, Color.GREEN),
-		BRIGHT_RED(5, PotionType.INSTANT_HEAL, Color.fromRGB(255,0,0)),
-		BLUE(6, PotionType.NIGHT_VISION, Color.NAVY),
-		BLACK(8, PotionType.WEAKNESS, Color.BLACK),
-		RED(9, PotionType.STRENGTH, Color.fromRGB(196,0,0)),
-		GREY(10, PotionType.SLOWNESS, Color.GRAY),
-		WATER(11, P.use1_9 ? PotionType.WATER_BREATHING : null, Color.BLUE),
-		DARK_RED(12, PotionType.INSTANT_DAMAGE, Color.fromRGB(128,0,0)),
-		BRIGHT_GREY(14, PotionType.INVISIBILITY, Color.SILVER);
+	public static class PotionColor {
+		public static final PotionColor PINK = new PotionColor(1, PotionType.REGEN, Color.FUCHSIA);
+		public static final PotionColor CYAN = new PotionColor(2, PotionType.SPEED, Color.AQUA);
+		public static final PotionColor ORANGE = new PotionColor(3, PotionType.FIRE_RESISTANCE, Color.ORANGE);
+		public static final PotionColor GREEN = new PotionColor(4, PotionType.POISON, Color.GREEN);
+		public static final PotionColor BRIGHT_RED = new PotionColor(5, PotionType.INSTANT_HEAL, Color.fromRGB(255,0,0));
+		public static final PotionColor BLUE = new PotionColor(6, PotionType.NIGHT_VISION, Color.NAVY);
+		public static final PotionColor BLACK = new PotionColor(8, PotionType.WEAKNESS, Color.BLACK);
+		public static final PotionColor RED = new PotionColor(9, PotionType.STRENGTH, Color.fromRGB(196,0,0));
+		public static final PotionColor GREY = new PotionColor(10, PotionType.SLOWNESS, Color.GRAY);
+		public static final PotionColor WATER = new PotionColor(11, P.use1_9 ? PotionType.WATER_BREATHING : null, Color.BLUE);
+		public static final PotionColor DARK_RED = new PotionColor(12, PotionType.INSTANT_DAMAGE, Color.fromRGB(128,0,0));
+		public static final PotionColor BRIGHT_GREY = new PotionColor(14, PotionType.INVISIBILITY, Color.SILVER);
 
 		private final int colorId;
 		private final PotionType type;
@@ -705,6 +705,12 @@ public class Brew {
 		PotionColor(int colorId, PotionType type, Color color) {
 			this.colorId = colorId;
 			this.type = type;
+			this.color = color;
+		}
+
+		public PotionColor(Color color) {
+			colorId = -1;
+			type = null;
 			this.color = color;
 		}
 
@@ -736,6 +742,33 @@ public class Brew {
 				}
 			} else {
 				potion.setDurability(getColorId(destillable));
+			}
+		}
+
+		public static PotionColor fromString(String string) {
+			switch (string) {
+				case "PINK": return PINK;
+				case "CYAN": return CYAN;
+				case "ORANGE": return ORANGE;
+				case "GREEN": return GREEN;
+				case "BRIGHT_RED": return BRIGHT_RED;
+				case "BLUE": return BLUE;
+				case "BLACK": return BLACK;
+				case "RED": return RED;
+				case "GREY": return GREY;
+				case "WATER": return WATER;
+				case "DARK_RED": return DARK_RED;
+				case "BRIGHT_GREY": return BRIGHT_GREY;
+				default:
+					try{
+						return new PotionColor(Color.fromRGB(
+							Integer.parseInt(string.substring( 1, 3 ), 16 ),
+							Integer.parseInt(string.substring( 3, 5 ), 16 ),
+							Integer.parseInt(string.substring( 5, 7 ), 16 )
+						));
+					} catch (Exception e) {
+						return WATER;
+					}
 			}
 		}
 

--- a/src/com/dre/brewery/listeners/InventoryListener.java
+++ b/src/com/dre/brewery/listeners/InventoryListener.java
@@ -277,7 +277,7 @@ public class InventoryListener implements Listener {
 						BRecipe recipe = brew.getCurrentRecipe();
 						if (recipe != null) {
 							Brew.removeEffects(potion);
-							Brew.PotionColor.valueOf(recipe.getColor()).colorBrew(potion, item, brew.canDistill());
+							Brew.PotionColor.fromString(recipe.getColor()).colorBrew(potion, item, brew.canDistill());
 							item.setItemMeta(potion);
 						}
 					}


### PR DESCRIPTION
This resolves #177.

Usage example: `color: "#ffad00"` instead of an enum value.

Works with versions 1.11+ where RGB potion colors had been added.