### PR TITLE
Load World Data asynchronously

### DIFF
--- a/src/com/dre/brewery/P.java
+++ b/src/com/dre/brewery/P.java
@@ -103,7 +103,7 @@ public class P extends JavaPlugin {
 		playerListener = new PlayerListener();
 		entityListener = new EntityListener();
 		inventoryListener = new InventoryListener();
-		worldListener = new WorldListener();
+		worldListener = new WorldListener(this);
 		integrationListener = new IntegrationListener();
 		PluginCommand c = getCommand("Brewery");
 		if (c != null) {

--- a/src/com/dre/brewery/filedata/BData.java
+++ b/src/com/dre/brewery/filedata/BData.java
@@ -266,14 +266,14 @@ public class BData {
 	}
 
 	// load Block locations of given world
-	public static void loadWorldData(String uuid, World world, FileConfiguration data) {
+	public static FileConfiguration loadWorldData(String uuid, World world, FileConfiguration data) {
 
 		if (data == null) {
 			File file = new File(P.p.getDataFolder(), "data.yml");
 			if (file.exists()) {
 				data = YamlConfiguration.loadConfiguration(file);
 			} else {
-				return;
+				return null;
 			}
 		}
 
@@ -393,5 +393,6 @@ public class BData {
 			}
 		}
 
+		return data;
 	}
 }

--- a/src/com/dre/brewery/listeners/WorldListener.java
+++ b/src/com/dre/brewery/listeners/WorldListener.java
@@ -8,6 +8,7 @@ import com.dre.brewery.filedata.BData;
 import com.dre.brewery.filedata.DataSave;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -17,6 +18,7 @@ import org.bukkit.event.world.WorldUnloadEvent;
 public class WorldListener implements Listener {
 
 	private final P p;
+	private FileConfiguration worldData;
 
 	public WorldListener(P p) {
 		this.p = p;
@@ -26,13 +28,12 @@ public class WorldListener implements Listener {
 	public void onWorldLoad(WorldLoadEvent event) {
 		World world = event.getWorld();
 
-		Bukkit.getScheduler().runTaskAsynchronously(p, () -> {
-			if (world.getName().startsWith("DXL_")) {
-				BData.loadWorldData(BUtil.getDxlName(world.getName()), world, null);
-			} else {
-				BData.loadWorldData(world.getUID().toString(), world, null);
-			}
-		});
+		if (worldData == null) {
+			worldData = BData.loadWorldData(world.getName().startsWith("DXL_") ? BUtil.getDxlName(world.getName()) : world.getUID().toString(), world, null);
+		} else {
+			Bukkit.getScheduler().runTaskAsynchronously(p,
+				() -> BData.loadWorldData(world.getName().startsWith("DXL_") ? BUtil.getDxlName(world.getName()) : world.getUID().toString(), world, worldData));
+		}
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/com/dre/brewery/listeners/WorldListener.java
+++ b/src/com/dre/brewery/listeners/WorldListener.java
@@ -2,9 +2,11 @@ package com.dre.brewery.listeners;
 
 import com.dre.brewery.BCauldron;
 import com.dre.brewery.Barrel;
+import com.dre.brewery.P;
 import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.filedata.BData;
 import com.dre.brewery.filedata.DataSave;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -14,15 +16,23 @@ import org.bukkit.event.world.WorldUnloadEvent;
 
 public class WorldListener implements Listener {
 
+	private final P p;
+
+	public WorldListener(P p) {
+		this.p = p;
+	}
+
 	@EventHandler
 	public void onWorldLoad(WorldLoadEvent event) {
 		World world = event.getWorld();
 
-		if (world.getName().startsWith("DXL_")) {
-			BData.loadWorldData(BUtil.getDxlName(world.getName()), world, null);
-		} else {
-			BData.loadWorldData(world.getUID().toString(), world, null);
-		}
+		Bukkit.getScheduler().runTaskAsynchronously(p, () -> {
+			if (world.getName().startsWith("DXL_")) {
+				BData.loadWorldData(BUtil.getDxlName(world.getName()), world, null);
+			} else {
+				BData.loadWorldData(world.getUID().toString(), world, null);
+			}
+		});
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)


### PR DESCRIPTION
There may be fallout due to this change, but the synchronous loading of the same data.yml file for successive World Load Events can cause server bootups to take very very long. In our case we have 17 worlds on startup with our data.yml file being 2.8mb. In the old, synchronous behavior this made the World Loading time of our server startup take about 18 seconds. With this change being asynchronous, it took 3s in total.

Further work could be done to retain the loaded config file since it is unlikely to be different on startup. This way you wouldn't be loading the same FileConfiguration X times over. But this seems to work for now I believe.