### PR TITLE
Fix invalid artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Also see  [Wiki](https://github.com/DieReicheErethons/Brewery/wiki) | [Releases]
 </repository>
 
 <dependency>
-   <groupId>com.de</groupId>
-   <artifactId>Brewery</artifactId>
+   <groupId>com.dre</groupId>
+   <artifactId>brewery</artifactId>
    <version>2.1.1</version>
    <scope>provided</scope>
 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
 		<dependency>
 			<groupId>com.acrobot.chestshop</groupId>
 			<artifactId>chestshop</artifactId>
-			<version>3.10.1</version>
+			<version>3.11</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.dre</groupId>
-	<artifactId>Brewery</artifactId>
+	<artifactId>brewery</artifactId>
 	<version>2.1.1</version>
 	<name>Brewery</name>
 


### PR DESCRIPTION
It is impossible to depend on brewery via maven because the artifact id is named `Brewery` with uppercase `B` but the path inside the repository is `brewery` with lower case `b`: https://zebradrive.de/maven/com/dre/brewery/

Also fixed typo in group id.