### PR TITLE
Only save data synchronously on World Unload if the plugin is shutting down.

### DIFF
--- a/src/com/dre/brewery/P.java
+++ b/src/com/dre/brewery/P.java
@@ -55,6 +55,9 @@ public class P extends JavaPlugin {
 	public int brewsCreatedCmd; // Created by command
 	public int exc, good, norm, bad, terr; // Brews drunken with quality
 
+	// States
+	public boolean shuttingDown;
+
 	@Override
 	public void onEnable() {
 		p = this;
@@ -142,6 +145,7 @@ public class P extends JavaPlugin {
 
 	@Override
 	public void onDisable() {
+		shuttingDown = true;
 
 		// Disable listeners
 		HandlerList.unregisterAll(this);

--- a/src/com/dre/brewery/listeners/WorldListener.java
+++ b/src/com/dre/brewery/listeners/WorldListener.java
@@ -45,7 +45,7 @@ public class WorldListener implements Listener {
 
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onWorldUnload(WorldUnloadEvent event) {
-		DataSave.save(true);
+		DataSave.save(P.p.shuttingDown);
 		String worldName = event.getWorld().getName();
 		Barrel.onUnload(worldName);
 		BCauldron.onUnload(worldName);


### PR DESCRIPTION
It cannot be assumed that all WorldUnloadEvents are called because the server is shutting down. As a result, any plugin that unloads worlds while running will suffer a big lagspike due to the synchronous data save. This PR just allows WorldUnloadEvents to save data asynchronously if the plugin isn't shutting down.