### PR TITLE
Added Sink for Dumping Potions

### DIFF
--- a/src/com/dre/brewery/BSink.java
+++ b/src/com/dre/brewery/BSink.java
@@ -1,0 +1,42 @@
+package com.dre.brewery;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class BSink {
+	private final Block block;
+	public static Map<Block, BSink> bsinks = new HashMap<>();
+	
+	public BSink(Block block) {
+		this.block = block;
+	}
+	
+	public static void add(Block block, BSink sink) {
+		
+	}
+	
+	public static void clickSink(PlayerInteractEvent event) {
+		Material materialInHand = event.getMaterial();
+		ItemStack item = event.getItem();
+		Block clickedBlock = event.getClickedBlock();
+		
+		if (materialInHand == Material.POTION) {
+			BSink sink = bsinks.get(clickedBlock);
+			
+			if (sink == null) {
+				sink = new BSink(clickedBlock);
+				bsinks.put(clickedBlock, sink);
+			}
+			
+			item.setAmount(0);
+			BCauldron.setItemInHand(event, Material.GLASS_BOTTLE, false);
+			event.setCancelled(true);
+		}
+	}
+}

--- a/src/com/dre/brewery/listeners/PlayerListener.java
+++ b/src/com/dre/brewery/listeners/PlayerListener.java
@@ -40,6 +40,11 @@ public class PlayerListener implements Listener {
 			return;
 		}
 
+		// Interacting with a Sink
+		if (type == Material.HOPPER) {
+			BSink.clickSink(event);
+			return;
+		}
 
 		if (P.use1_14 && BSealer.isBSealer(clickedBlock)) {
 			event.setCancelled(true);


### PR DESCRIPTION
The Sink (Currently Hopper) allows for players to dump failed brews so that they dont have to drink them inorder to get empty bottles back.

Based on Uboaaaaa's idea (https://github.com/DieReicheErethons/Brewery/issues/327)