### PR TITLE
Allow brew recipes to reduce alcohol level

### DIFF
--- a/resources/config/v12/en/config.yml
+++ b/resources/config/v12/en/config.yml
@@ -442,6 +442,7 @@ recipes:
       cookingtime: 2
       color: BLACK
       difficulty: 3
+      alcohol: -6
       lore: + &8Probably a week old
       effects:
       - REGENERATION/1/2-5

--- a/resources/config/v13/de/config.yml
+++ b/resources/config/v13/de/config.yml
@@ -821,6 +821,7 @@ recipes:
   #   cookingtime: 1
   #   color: BLACK
   #   difficulty: 4
+  #   alcohol: -8
   #   effects:
   #     - REGENERATION/30
   #     - SPEED/10

--- a/resources/config/v13/en/config.yml
+++ b/resources/config/v13/en/config.yml
@@ -739,6 +739,7 @@ recipes:
     cookingtime: 2
     color: BLACK
     difficulty: 3
+    alcohol: -6
     lore: + &8Probably a week old
     effects:
       - REGENERATION/1/2-5
@@ -816,6 +817,7 @@ recipes:
   #   cookingtime: 1
   #   color: BLACK
   #   difficulty: 4
+  #   alcohol: -8
   #   effects:
   #     - REGENERATION/30
   #     - SPEED/10

--- a/resources/config/v13/es/config.yml
+++ b/resources/config/v13/es/config.yml
@@ -739,6 +739,7 @@ recipes:
     cookingtime: 2
     color: BLACK
     difficulty: 3
+    alcohol: -6
     lore: + &8Probablemente una semana de edad
     effects:
       - REGENERATION/1/2-5
@@ -816,6 +817,7 @@ recipes:
   #   cookingtime: 1
   #   color: BLACK
   #   difficulty: 4
+  #   alcohol: -8
   #   effects:
   #     - REGENERATION/30
   #     - SPEED/10

--- a/resources/config/v13/fr/config.yml
+++ b/resources/config/v13/fr/config.yml
@@ -746,6 +746,7 @@ recipes:
     cookingtime: 2
     color: BLACK
     difficulty: 3
+    alcohol: -6
     lore: + &8Probably a week old
     effects:
       - REGENERATION/1/2-5
@@ -822,6 +823,7 @@ recipes:
   #   cookingtime: 1
   #   color: BLACK
   #   difficulty: 4
+  #   alcohol: -8
   #   effects:
   #     - REGENERATION/30
   #     - SPEED/10

--- a/resources/config/v13/it/config.yml
+++ b/resources/config/v13/it/config.yml
@@ -816,6 +816,7 @@ eggnog:
   #   cookingtime: 1
   #   color: BLACK
   #   difficulty: 4
+  #   alcohol: -8
   #   effects:
   #     - REGENERATION/30
   #     - SPEED/10

--- a/resources/config/v13/zh/config.yml
+++ b/resources/config/v13/zh/config.yml
@@ -820,6 +820,7 @@ recipes:
   #   cookingtime: 1
   #   color: BLACK
   #   difficulty: 4
+  #   alcohol: -6
   #   effects:
   #     - REGENERATION/30
   #     - SPEED/10

--- a/src/com/dre/brewery/BPlayer.java
+++ b/src/com/dre/brewery/BPlayer.java
@@ -180,21 +180,25 @@ public class BPlayer {
 		int quality = drinkEvent.getQuality();
 		List<PotionEffect> effects = getBrewEffects(brew.getEffects(), quality);
 
-		if (brewAlc < 1) {
+		if (brewAlc == 0) {
 			//no alcohol so we dont need to add a BPlayer
 			applyEffects(effects, player, PlayerEffectEvent.EffectType.DRINK);
 			if (bPlayer.drunkeness <= 0) {
 				bPlayer.remove();
 			}
-			return true;
 		}
 
-		bPlayer.drunkeness += brewAlc;
-		if (quality > 0) {
-			bPlayer.quality += quality * brewAlc;
+		if (brewAlc > 0) {
+			bPlayer.drunkeness += brewAlc;
+			if (quality > 0) {
+				bPlayer.quality += quality * brewAlc;
+			} else {
+				bPlayer.quality += brewAlc;
+			}
 		} else {
-			bPlayer.quality += brewAlc;
+			bPlayer.drainAndRemove(player, -brewAlc);
 		}
+
 		applyEffects(effects, player, PlayerEffectEvent.EffectType.DRINK);
 		applyEffects(getQualityEffects(quality, brewAlc), player, PlayerEffectEvent.EffectType.QUALITY);
 
@@ -202,6 +206,7 @@ public class BPlayer {
 			bPlayer.drinkCap(player);
 		}
 		bPlayer.syncToSQL(false);
+		
 		if (BConfig.showStatusOnDrink) {
 			bPlayer.showDrunkeness(player);
 		}
@@ -336,7 +341,11 @@ public class BPlayer {
 	// Eat something to drain the drunkeness
 	public void drainByItem(Player player, Material mat) {
 		int strength = BConfig.drainItems.get(mat);
-		if (drain(player, strength)) {
+		drainAndRemove(player, strength);
+	}
+
+	public void drainAndRemove(Player player, int amount) {
+		if (drain(player, amount)) {
 			remove(player);
 		}
 	}

--- a/src/com/dre/brewery/BPlayer.java
+++ b/src/com/dre/brewery/BPlayer.java
@@ -182,7 +182,7 @@ public class BPlayer {
 
 		applyEffects(effects, player, PlayerEffectEvent.EffectType.DRINK);
 		if (brewAlc < 0) {
-			bPlayer.drainAndRemove(player, -brewAlc);
+			bPlayer.drain(player, -brewAlc);
 		} else if (brewAlc > 0) {
 			bPlayer.drunkeness += brewAlc;
 			if (quality > 0) {
@@ -337,11 +337,7 @@ public class BPlayer {
 	// Eat something to drain the drunkeness
 	public void drainByItem(Player player, Material mat) {
 		int strength = BConfig.drainItems.get(mat);
-		drainAndRemove(player, strength);
-	}
-
-	public void drainAndRemove(Player player, int amount) {
-		if (drain(player, amount)) {
+		if (drain(player, strength)) {
 			remove(player);
 		}
 	}

--- a/src/com/dre/brewery/BPlayer.java
+++ b/src/com/dre/brewery/BPlayer.java
@@ -180,28 +180,20 @@ public class BPlayer {
 		int quality = drinkEvent.getQuality();
 		List<PotionEffect> effects = getBrewEffects(brew.getEffects(), quality);
 
-		if (brewAlc == 0) {
-			//no alcohol so we dont need to add a BPlayer
-			applyEffects(effects, player, PlayerEffectEvent.EffectType.DRINK);
-			if (bPlayer.drunkeness <= 0) {
-				bPlayer.remove();
-			}
-		}
-
-		if (brewAlc > 0) {
+		applyEffects(effects, player, PlayerEffectEvent.EffectType.DRINK);
+		if (brewAlc < 0) {
+			bPlayer.drainAndRemove(player, -brewAlc);
+		} else if (brewAlc > 0) {
 			bPlayer.drunkeness += brewAlc;
 			if (quality > 0) {
 				bPlayer.quality += quality * brewAlc;
 			} else {
 				bPlayer.quality += brewAlc;
 			}
-		} else {
-			bPlayer.drainAndRemove(player, -brewAlc);
+			
+			applyEffects(getQualityEffects(quality, brewAlc), player, PlayerEffectEvent.EffectType.QUALITY);
 		}
-
-		applyEffects(effects, player, PlayerEffectEvent.EffectType.DRINK);
-		applyEffects(getQualityEffects(quality, brewAlc), player, PlayerEffectEvent.EffectType.QUALITY);
-
+		
 		if (bPlayer.drunkeness > 100) {
 			bPlayer.drinkCap(player);
 		}
@@ -209,6 +201,10 @@ public class BPlayer {
 		
 		if (BConfig.showStatusOnDrink) {
 			bPlayer.showDrunkeness(player);
+		}
+
+		if (bPlayer.drunkeness <= 0) {
+			bPlayer.remove();
 		}
 		return true;
 	}

--- a/src/com/dre/brewery/Brew.java
+++ b/src/com/dre/brewery/Brew.java
@@ -373,9 +373,7 @@ public class Brew implements Cloneable {
 				// quality decides 10% - 100%
 				alc *= ((float) quality / 10.0f);
 			}
-			if (alc > 0) {
-				return alc;
-			}
+			return alc;
 		}
 		return 0;
 	}
@@ -516,7 +514,10 @@ public class Brew implements Cloneable {
 	}
 
 	public int getOrCalcAlc() {
-		return alc > 0 ? alc : (alc = calcAlcohol());
+		if (alc == 0) {
+			alc = calcAlcohol();
+		}
+		return alc;
 	}
 
 	public void setAlc(int alc) {

--- a/src/com/dre/brewery/lore/BrewLore.java
+++ b/src/com/dre/brewery/lore/BrewLore.java
@@ -275,7 +275,7 @@ public class BrewLore {
 	}
 
 	public void updateAlc(boolean inDistiller) {
-		if (!brew.isUnlabeled() && (inDistiller || BConfig.alwaysShowAlc) && (!brew.hasRecipe() || brew.getCurrentRecipe().getAlcohol() > 0)) {
+		if (!brew.isUnlabeled() && (inDistiller || BConfig.alwaysShowAlc) && (!brew.hasRecipe() || brew.getCurrentRecipe().getAlcohol() != 0)) {
 			int alc = brew.getOrCalcAlc();
 			addOrReplaceLore(Type.ALC, "§8", P.p.languageReader.get("Brew_Alc", alc + ""));
 		} else {

--- a/src/com/dre/brewery/recipe/BRecipe.java
+++ b/src/com/dre/brewery/recipe/BRecipe.java
@@ -338,10 +338,6 @@ public class BRecipe {
 			P.p.errorLog("Invalid difficulty '" + difficulty + "' in Recipe: " + getRecipeName());
 			return false;
 		}
-		if (alcohol < 0) {
-			P.p.errorLog("Invalid alcohol '" + alcohol + "' in Recipe: " + getRecipeName());
-			return false;
-		}
 		return true;
 	}
 


### PR DESCRIPTION
Recipes can be set to have negative alcohol, which will reduce alcohol level upon drinking. Changed default config files to give coffee an alcohol of -6 and iced coffee an alcohol of -8.

Suggested by Fire177 (#297)