### PR TITLE
Alcohol tolerance via permissions

### DIFF
--- a/resources/config/v13/en/config.yml
+++ b/resources/config/v13/en/config.yml
@@ -89,6 +89,55 @@ debug: false
 # Config Version
 version: '3.0'
 
+# The number of steps when searching for a tolerance value in permissions might impact server performance
+# For increased flexibility in addition to potential performance tweaks, you can define how Brewery searches for those values here
+# You can remove this section or leave it blank for default behavior
+# Some example configurations are provided
+toleranceRanges:
+  # Search from 100 to 0, incrementing by -1 (i.e. use the highest recovery permission the user has)
+  # if no value is found (i.e. the user doesn't have any brewery.tolerance.recovery permissions), default to 2
+  recovery:
+    from: 100
+    to: 0
+    incr: -1
+    def: 2
+
+  # Search from 200 to 0, incrementing by -1 (i.e. use the highest sensitivity permission the user has)
+  # if no value is found (i.e. the user doesn't have any brewery.tolerance.sensitivity permissions), default to 100
+  sensitivity:
+    from: 200
+    to: 0
+    incr: -1
+    def: 100
+
+#  # You can completely ignore permissions (eliminating any potential performance issues) by setting 'incr: 0'
+#  # In this example, everyone regardless of permissions has a recovery of 33
+#  recovery:
+#    incr: 0
+#    def: 33
+#
+#  # Another way to completely ignore permissions is by setting 'to' and 'from' to the same value (it can be any value)
+#  # In this example, everyone regardless of permissions has a sensitivity of 115
+#  sensitivity:
+#    from: 5
+#    to: 5
+#    def: 115
+#
+#  # Use the lowest recovery permission for a user (normally uses the highest)
+#  # The sign of incr is automatically changed to match, and therefore doesn't need to be specified
+#  recovery:
+#    from: 0
+#    to: 100
+#
+#  # Allow sensitivity from 0 to 500 (i.e. alcohol multiplier of x0 to x5) but only allow increments of 25
+#  # If a player doesn't have a permission value that's a multiple of 25, it'll be completely ignored
+#  # e.g. if a player's only perm is brewery.tolerance.sensitivity20, they will receive the default sensitivity of 80
+#  # note: using 'incr: 25' would result in identical behavior; Brewery will automatically change the sign of incr to match the 'from' and 'to' values.
+#  sensitivity:
+#    from: 500
+#    to: 0
+#    incr: -25
+#    def: 80
 
 
 # -- Define custom items --

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -21,8 +21,6 @@ permissions:
       brewery.cauldron.time: true
       brewery.cauldron.insert: true
       brewery.cauldron.fill: true
-      brewery.tolerance.sensitivity100: true
-      brewery.tolerance.recovery2: true
 # Mod
   brewery.mod:
     description: Allow to maintain Wakeup Points and to login even if overdrunken

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -21,6 +21,8 @@ permissions:
       brewery.cauldron.time: true
       brewery.cauldron.insert: true
       brewery.cauldron.fill: true
+      brewery.tolerance.sensitivity100: true
+      brewery.tolerance.recovery2: true
 # Mod
   brewery.mod:
     description: Allow to maintain Wakeup Points and to login even if overdrunken

--- a/src/com/dre/brewery/BPlayer.java
+++ b/src/com/dre/brewery/BPlayer.java
@@ -8,7 +8,7 @@ import com.dre.brewery.filedata.BConfig;
 import com.dre.brewery.lore.BrewLore;
 import com.dre.brewery.recipe.BEffect;
 import com.dre.brewery.utility.BUtil;
-import com.dre.brewery.utility.PermissionUtil;
+import com.dre.brewery.utility.PermissionNumberRange;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.apache.commons.lang.mutable.MutableInt;
@@ -177,7 +177,7 @@ public class BPlayer {
 		}
 		P.p.metricsForDrink(brew);
 
-		int alcImmunity = PermissionUtil.getHighestPerm(player, "brewery.tolerance.sensitivity", 200, 100);
+		int alcImmunity = PermissionNumberRange.getPermNum("brewery.tolerance.sensitivity", player);
 		int brewAlc = (int)Math.round(drinkEvent.getAddedAlcohol() * ((float)alcImmunity / 100.0));
 		int quality = drinkEvent.getQuality();
 		List<PotionEffect> effects = getBrewEffects(brew.getEffects(), quality);
@@ -810,7 +810,7 @@ public class BPlayer {
 				BPlayer bplayer = entry.getValue();
 				Player player = BUtil.getPlayerfromString(uuid);
 				
-				int soberPerMin = PermissionUtil.getHighestPerm(player, "brewery.tolerance.recovery", 100, 2);
+				int soberPerMin = PermissionNumberRange.getPermNum("brewery.tolerance.recovery", player);
 				if (bplayer.drunkeness == soberPerMin) {
 					// Prevent 0 drunkeness
 					soberPerMin++;

--- a/src/com/dre/brewery/filedata/BConfig.java
+++ b/src/com/dre/brewery/filedata/BConfig.java
@@ -19,6 +19,7 @@ import com.dre.brewery.recipe.BRecipe;
 import com.dre.brewery.recipe.PluginItem;
 import com.dre.brewery.recipe.RecipeItem;
 import com.dre.brewery.utility.BUtil;
+import com.dre.brewery.utility.PermissionNumberRange;
 import com.dre.brewery.utility.SQLSync;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -215,6 +216,20 @@ public class BConfig {
 		hasChestShop = plMan.isPluginEnabled("ChestShop");
 		hasShopKeepers = plMan.isPluginEnabled("Shopkeepers");
 
+		// Permission numbers
+		String permNumPrefix = "brewery.tolerance.";
+		PermissionNumberRange.register(permNumPrefix, "sensitivity", 200, 0, -1, 100);
+		PermissionNumberRange.register(permNumPrefix, "recovery", 100, 0, -1, 2);
+		ConfigurationSection configSection = config.getConfigurationSection("toleranceRanges");
+		if (configSection != null) {
+			for (String pnNode : configSection.getKeys(false)) {
+				boolean validUpdate = PermissionNumberRange.updateFromConfig(configSection, permNumPrefix, pnNode);
+				if (!validUpdate) {
+					p.errorLog("Trying to update non-existant permission number: '" + permNumPrefix + pnNode + "'!");
+				}
+			}
+		}
+
 		// various Settings
 		DataSave.autosave = config.getInt("autosave", 3);
 		P.debug = config.getBoolean("debug", false);
@@ -259,7 +274,7 @@ public class BConfig {
 		PluginItem.registerForConfig("exoticgarden", SlimefunPluginItem::new);
 
 		// Loading custom items
-		ConfigurationSection configSection = config.getConfigurationSection("customItems");
+		configSection = config.getConfigurationSection("customItems");
 		if (configSection != null) {
 			for (String custId : configSection.getKeys(false)) {
 				RecipeItem custom = RecipeItem.fromConfigCustom(configSection, custId);

--- a/src/com/dre/brewery/utility/PermissionNumberRange.java
+++ b/src/com/dre/brewery/utility/PermissionNumberRange.java
@@ -1,0 +1,95 @@
+package com.dre.brewery.utility;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.dre.brewery.P;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.permissions.Permissible;
+import org.jetbrains.annotations.Nullable;
+
+public class PermissionNumberRange {
+    public static Map<String, PermissionNumberRange> permNums = new HashMap<>();
+    
+    public static void register(String nodePrefix, String lastNode, int from, int to, int incr, int def) {
+        PermissionNumberRange pn = new PermissionNumberRange(nodePrefix + lastNode, from, to, incr, def);
+        permNums.put(pn.permNode, pn);
+    }
+
+	@Nullable
+	public static boolean updateFromConfig(ConfigurationSection sec, String nodePrefix, String lastNode) {
+        boolean validKey = permNums.containsKey(nodePrefix + lastNode);
+        if (validKey) {
+            PermissionNumberRange pn = permNums.get(nodePrefix + lastNode);
+            pn.searchFrom = sec.getInt(lastNode + ".from", pn.searchFrom);
+            pn.searchTo = sec.getInt(lastNode + ".to", pn.searchTo);
+            pn.searchIncr = sec.getInt(lastNode + ".incr", pn.searchIncr);
+            pn.defaultVal = sec.getInt(lastNode + ".default", pn.defaultVal);
+            pn.enforceValidIncrement();
+        }
+        return validKey;
+	}
+
+	/**
+	 * Finds the largest value given by a permission node that ends in an integer
+	 * @param permNode the node without an integer (eg for brewery.tolerance.recovery75, permNode is "brewery.tolerance.recovery")
+	 * @param p the Permissible (player/sender/etc) to check the permission of
+	 * @return the highest-value integer of the nodes consisting of the permNode
+	 */
+    public static int getPermNum(String permNode, Permissible p) {
+        if (permNums.containsKey(permNode)) {
+            return permNums.get(permNode).getPermNumOf(p);
+        }
+        P.p.errorLog("Failed to find permission number node " + permNode);
+        return 0;
+    }
+
+
+
+    private int searchFrom = 100;
+    private int searchTo = 0;
+    private int searchIncr = 1;
+    int defaultVal = 0;
+    String permNode = "";
+    
+    public PermissionNumberRange(String fullNode, int from, int to, int incr, int def) {
+        setSearch(from, to, incr);
+        defaultVal = def;
+        permNode = fullNode;
+    }
+
+    public void setSearch(int from, int to, int incr) {
+        searchFrom = from;
+        searchTo = to;
+        searchIncr = incr;
+        enforceValidIncrement();
+    }
+
+    private void enforceValidIncrement() {
+        if (searchFrom > searchTo && searchIncr > 0) {
+            searchIncr = -1;
+        }
+        if (searchFrom < searchTo && searchIncr < 0) {
+            searchIncr = 1;
+        }
+    }
+    
+	/**
+	 * @see PermissionNumberRange#getPermNum
+	 */
+	public int getPermNumOf(Permissible p) {
+        if (searchTo == searchFrom || searchIncr == 0) {
+            return defaultVal;
+        }
+        
+        int i = searchFrom;
+        while (searchIncr > 0 ? i <= searchTo : i >= searchTo) {
+			if (p.hasPermission(permNode + i)) {
+				return i;
+            }
+            i += searchIncr;
+        }
+        return defaultVal;
+	}
+}

--- a/src/com/dre/brewery/utility/PermissionNumberRange.java
+++ b/src/com/dre/brewery/utility/PermissionNumberRange.java
@@ -66,12 +66,12 @@ public class PermissionNumberRange {
         enforceValidIncrement();
     }
 
+    /**
+     * Changes the sign of searchIncr to match the direction of searching from searchFrom to searchTo
+     */
     private void enforceValidIncrement() {
-        if (searchFrom > searchTo && searchIncr > 0) {
-            searchIncr = -1;
-        }
-        if (searchFrom < searchTo && searchIncr < 0) {
-            searchIncr = 1;
+        if ((searchFrom > searchTo && searchIncr > 0) || (searchFrom < searchTo && searchIncr < 0)) {
+            searchIncr *= -1;
         }
     }
     
@@ -82,7 +82,7 @@ public class PermissionNumberRange {
         if (searchTo == searchFrom || searchIncr == 0) {
             return defaultVal;
         }
-        
+
         int i = searchFrom;
         while (searchIncr > 0 ? i <= searchTo : i >= searchTo) {
 			if (p.hasPermission(permNode + i)) {

--- a/src/com/dre/brewery/utility/PermissionUtil.java
+++ b/src/com/dre/brewery/utility/PermissionUtil.java
@@ -121,30 +121,4 @@ public class PermissionUtil {
 			return null;
 		}
 	}
-
-	/**
-	 * Finds the largest value given by a permission node that ends in an integer
-	 * @param p the Permissible (player/sender/etc) to check the permission of
-	 * @param permPrefix the node without an integer (eg for brewery.tolerance.recovery75, permPrefix is brewery.tolerance.recovery)
-	 * @param highestVal the highest possible value to check for
-	 * @param defaultVal the value to use if no nodes are found
-	 * @param lowestVal the lowest possible value to check for
-	 * @return the highest-value integer of the nodes consisting of permPrefix + int
-	 */
-	public static int getHighestPerm(Permissible p, String permPrefix, int lowestVal, int highestVal, int defaultVal) {
-		for (int i = highestVal; i >= lowestVal; i--) {
-			if (p.hasPermission(permPrefix + i)) {
-				return i;
-			}
-		}
-		return defaultVal;
-	}
-
-	/**
-	 * the same as {@link PermissionUtil#getHighestPerm} but assumes a lowestVal of 0
-	 * @see PermissionUtil#getHighestPerm
-	 */
-	public static int getHighestPerm(Permissible p, String permPrefix, int highestVal, int defaultVal) {
-		return getHighestPerm(p, permPrefix, highestVal, 0, defaultVal);
-	}
 }

--- a/src/com/dre/brewery/utility/PermissionUtil.java
+++ b/src/com/dre/brewery/utility/PermissionUtil.java
@@ -1,6 +1,7 @@
 package com.dre.brewery.utility;
 
 import org.bukkit.command.CommandSender;
+import org.bukkit.permissions.Permissible;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -119,5 +120,31 @@ public class PermissionUtil {
 			}
 			return null;
 		}
+	}
+
+	/**
+	 * Finds the largest value given by a permission node that ends in an integer
+	 * @param p the Permissible (player/sender/etc) to check the permission of
+	 * @param permPrefix the node without an integer (eg for brewery.tolerance.recovery75, permPrefix is brewery.tolerance.recovery)
+	 * @param highestVal the highest possible value to check for
+	 * @param defaultVal the value to use if no nodes are found
+	 * @param lowestVal the lowest possible value to check for
+	 * @return the highest-value integer of the nodes consisting of permPrefix + int
+	 */
+	public static int getHighestPerm(Permissible p, String permPrefix, int lowestVal, int highestVal, int defaultVal) {
+		for (int i = highestVal; i >= lowestVal; i--) {
+			if (p.hasPermission(permPrefix + i)) {
+				return i;
+			}
+		}
+		return defaultVal;
+	}
+
+	/**
+	 * the same as {@link PermissionUtil#getHighestPerm} but assumes a lowestVal of 0
+	 * @see PermissionUtil#getHighestPerm
+	 */
+	public static int getHighestPerm(Permissible p, String permPrefix, int highestVal, int defaultVal) {
+		return getHighestPerm(p, permPrefix, highestVal, 0, defaultVal);
 	}
 }


### PR DESCRIPTION
As suggested in #146, adds two number permissions to change specific player tolerances to alcohol. The permissions are `brewery.tolerance.sensitivity` and `brewery.tolerance.recovery`. Sensitivity affects how much alcohol level increases when drinking, e.g. `brewery.tolerance.sensitivity50` means you only receive 50% of the drunkeness from a drink, `brewery.tolerance.sensitivity150` means you receive 150% of it. Recovery affects the "sober per min," so `brewery.tolerance.recovery2` means 2 drunkeness is lost every minute.

Bukkit permissions with numbers isn't really supported normally, so the plugin will iteratively check for permissions along a range. This might affect performance negatively. To help reduce potential performance problems and also provide greater flexibility to server admins, the permission number ranges are customizable in the config file. This means that if an admin wants to ignore permissions completely (thus eliminating any performance effects from this PR) and still change the default values for recovery and sensitivity, they can do so very easily. I put sample configurations and explanations in the English config file.