### PR TITLE
Change recipe validity check to allow 7/8 as wood types

### DIFF
--- a/src/com/dre/brewery/recipe/BRecipe.java
+++ b/src/com/dre/brewery/recipe/BRecipe.java
@@ -326,7 +326,7 @@ public class BRecipe {
 			P.p.errorLog("Invalid distilltime '" + distillTime + "' in Recipe: " + getRecipeName());
 			return false;
 		}
-		if (wood < 0 || wood > 6) {
+		if (wood < 0 || wood > 8) {
 			P.p.errorLog("Invalid wood type '" + wood + "' in Recipe: " + getRecipeName());
 			return false;
 		}


### PR DESCRIPTION
The 3.0 Brewery update added support for Crimson and Warped barrels, but as discussed in DieReicheErethons#361, recipes using the new wood types failed to load from the config when people tried making them. This PR changes the config validation method to allow recipes using the new wood types to be loaded.