### PR TITLE
force utf8 to save config.

### DIFF
--- a/src/com/dre/brewery/filedata/ConfigUpdater.java
+++ b/src/com/dre/brewery/filedata/ConfigUpdater.java
@@ -1,6 +1,7 @@
 package com.dre.brewery.filedata;
 
 import com.dre.brewery.P;
+import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.LegacyUtil;
 import com.dre.brewery.utility.Tuple;
 import org.bukkit.Material;
@@ -8,6 +9,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -79,13 +81,9 @@ public class ConfigUpdater {
 			stringBuilder.append(line).append("\n");
 		}
 		String configString = stringBuilder.toString().trim();
-
 		try {
-			BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-			writer.write(configString);
-			writer.flush();
-			writer.close();
-
+			InputStream utf8ConfigInput = new ByteArrayInputStream(configString.getBytes(StandardCharsets.UTF_8));
+			BUtil.saveFile(utf8ConfigInput, file, true);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -93,7 +91,7 @@ public class ConfigUpdater {
 
 	private void getConfigString() {
 		try {
-			BufferedReader reader = new BufferedReader(new FileReader(file));
+			BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 			String currentLine;
 			while((currentLine = reader.readLine()) != null) {
 				config.add(currentLine);

--- a/src/com/dre/brewery/utility/BUtil.java
+++ b/src/com/dre/brewery/utility/BUtil.java
@@ -358,4 +358,7 @@ public class BUtil {
 		out.close();
 	}
 
+	public static void saveFile(InputStream in, File file, boolean overwrite) throws IOException {
+		saveFile(in, file.getParentFile(), file.getName(), overwrite);
+	}
 }


### PR DESCRIPTION
I find that every time I restart the server after saving the Chinese configuration file, the configuration file will be garbled. That may be because the configuration file in the jar is utf8, and the platform encode is other, when the plugin saves the default configuration file, it will save utf8 as other encodes.  
I thought of two solutions: one is to force the configuration file to be saved in utf8 instead of platform encode; or to read the configuration file in the jar and save it as the platform encode, so that the encode in all places is the platform encode.
This pull request is the first way, i think force utf8 is better than use platform encode, but I also used the second solution in my other branch, if you don't like utf8 then you can consider [this](https://github.com/R-Josef/Brewery/tree/platform-encode).