### PR TITLE
Updated bStats to v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,13 @@
 						<configuration>
 							<artifactSet>
 								<includes>
-									<include>org.bstats:bstats-bukkit</include>
+									<include>org.bstats:*</include>
 								</includes>
 							</artifactSet>
 							<relocations>
 								<relocation>
-									<pattern>org.bstats.bukkit</pattern>
-									<shadedPattern>com.dre.brewery.integration</shadedPattern>
+									<pattern>org.bstats</pattern>
+									<shadedPattern>com.dre.brewery.integration.bstats</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>
@@ -98,7 +98,7 @@
 	<repositories>
 		<repository>
 			<id>md_5-public</id>
-			<url>http://repo.md-5.net/content/groups/public/</url>
+			<url>https://repo.md-5.net/content/groups/public/</url>
 		</repository>
 		<repository>
 			<id>spigot-repo</id>
@@ -106,12 +106,12 @@
 		</repository>
 		<repository>
 			<id>vault-repo</id>
-			<url>http://nexus.hc.to/content/repositories/pub_releases</url>
+			<url>https://nexus.hc.to/content/repositories/pub_releases</url>
 		</repository>
 		<repository>
 			<!-- WorldEdit, WorldGuard -->
 			<id>sk89q-repo</id>
-			<url>http://maven.sk89q.com/repo/</url>
+			<url>https://maven.sk89q.com/repo/</url>
 		</repository>
 		<repository>
 			<!-- GriefPrevention, SlimeFun, Towny, Brewery -->
@@ -127,11 +127,11 @@
 			<id>chestshop-repo</id>
 			<url>https://repo.minebench.de/</url>
 		</repository>
-		<repository>
-			<!-- bStats -->
-			<id>CodeMC</id>
-			<url>https://repo.codemc.org/repository/maven-public</url>
-		</repository>
+        <repository>
+            <!-- BlockLocker -->
+            <id>CodeMC</id>
+            <url>https://repo.codemc.org/repository/maven-public</url>
+        </repository>
 		<repository>
 			<!-- MythicLib (MMOItems) -->
 			<id>MMOPlugins</id>
@@ -297,7 +297,7 @@
 		<dependency>
 			<groupId>org.bstats</groupId>
 			<artifactId>bstats-bukkit</artifactId>
-			<version>1.5</version>
+			<version>2.2.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/src/com/dre/brewery/P.java
+++ b/src/com/dre/brewery/P.java
@@ -16,6 +16,7 @@ import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.LegacyUtil;
 import org.apache.commons.lang.math.NumberUtils;
 import org.bstats.bukkit.Metrics;
+import org.bstats.charts.*;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -286,12 +287,12 @@ public class P extends JavaPlugin {
 
 	private void setupMetrics() {
 		try {
-			Metrics metrics = new Metrics(this);
-			metrics.addCustomChart(new Metrics.SingleLineChart("drunk_players", BPlayer::numDrunkPlayers));
-			metrics.addCustomChart(new Metrics.SingleLineChart("brews_in_existence", () -> brewsCreated));
-			metrics.addCustomChart(new Metrics.SingleLineChart("barrels_built", () -> Barrel.barrels.size()));
-			metrics.addCustomChart(new Metrics.SingleLineChart("cauldrons_boiling", () -> BCauldron.bcauldrons.size()));
-			metrics.addCustomChart(new Metrics.AdvancedPie("brew_quality", () -> {
+			Metrics metrics = new Metrics(this, 3494);
+			metrics.addCustomChart(new SingleLineChart("drunk_players", BPlayer::numDrunkPlayers));
+			metrics.addCustomChart(new SingleLineChart("brews_in_existence", () -> brewsCreated));
+			metrics.addCustomChart(new SingleLineChart("barrels_built", Barrel.barrels::size));
+			metrics.addCustomChart(new SingleLineChart("cauldrons_boiling", BCauldron.bcauldrons::size));
+			metrics.addCustomChart(new AdvancedPie("brew_quality", () -> {
 				Map<String, Integer> map = new HashMap<>(8);
 				map.put("excellent", exc);
 				map.put("good", good);
@@ -300,14 +301,14 @@ public class P extends JavaPlugin {
 				map.put("terrible", terr);
 				return map;
 			}));
-			metrics.addCustomChart(new Metrics.AdvancedPie("brews_created", () -> {
+			metrics.addCustomChart(new AdvancedPie("brews_created", () -> {
 				Map<String, Integer> map = new HashMap<>(4);
 				map.put("by command", brewsCreatedCmd);
 				map.put("brewing", brewsCreated - brewsCreatedCmd);
 				return map;
 			}));
 
-			metrics.addCustomChart(new Metrics.SimplePie("number_of_recipes", () -> {
+			metrics.addCustomChart(new SimplePie("number_of_recipes", () -> {
 				int recipes = BRecipe.getAllRecipes().size();
 				if (recipes < 7) {
 					return "Less than 7";
@@ -339,7 +340,7 @@ public class P extends JavaPlugin {
 
 			}));
 
-			metrics.addCustomChart(new Metrics.SimplePie("wakeups", () -> {
+			metrics.addCustomChart(new SimplePie("wakeups", () -> {
 				if (!BConfig.enableHome) {
 					return "disabled";
 				}
@@ -356,7 +357,7 @@ public class P extends JavaPlugin {
 					return "More than 20";
 				}
 			}));
-			metrics.addCustomChart(new Metrics.SimplePie("v2_mc_version", () -> {
+			metrics.addCustomChart(new SimplePie("v2_mc_version", () -> {
 				String mcv = Bukkit.getBukkitVersion();
 				mcv = mcv.substring(0, mcv.indexOf('.', 2));
 				int index = mcv.indexOf('-');
@@ -370,7 +371,7 @@ public class P extends JavaPlugin {
 					return "undef";
 				}
 			}));
-			metrics.addCustomChart(new Metrics.DrilldownPie("plugin_mc_version", () -> {
+			metrics.addCustomChart(new DrilldownPie("plugin_mc_version", () -> {
 				Map<String, Map<String, Integer>> map = new HashMap<>(3);
 				String mcv = Bukkit.getBukkitVersion();
 				mcv = mcv.substring(0, mcv.indexOf('.', 2));
@@ -389,9 +390,9 @@ public class P extends JavaPlugin {
 				map.put(getDescription().getVersion(), innerMap);
 				return map;
 			}));
-			metrics.addCustomChart(new Metrics.SimplePie("language", () -> language));
-			metrics.addCustomChart(new Metrics.SimplePie("config_scramble", () -> BConfig.enableEncode ? "enabled" : "disabled"));
-			metrics.addCustomChart(new Metrics.SimplePie("config_lore_color", () -> {
+			metrics.addCustomChart(new SimplePie("language", () -> language));
+			metrics.addCustomChart(new SimplePie("config_scramble", () -> BConfig.enableEncode ? "enabled" : "disabled"));
+			metrics.addCustomChart(new SimplePie("config_lore_color", () -> {
 				if (BConfig.colorInBarrels) {
 					if (BConfig.colorInBrewer) {
 						return "both";
@@ -406,7 +407,7 @@ public class P extends JavaPlugin {
 					}
 				}
 			}));
-			metrics.addCustomChart(new Metrics.SimplePie("config_always_show", () -> {
+			metrics.addCustomChart(new SimplePie("config_always_show", () -> {
 				if (BConfig.alwaysShowQuality) {
 					if (BConfig.alwaysShowAlc) {
 						return "both";


### PR DESCRIPTION
Hi, I noticed that Brewery uses a pretty old version of bStats.
So I decided to update this dependency for you.
Most noteworthy, bStats uses an id-system nowadays and Brewery still sends its data to the deprecated non-id-compatible url.
Also important is that bStats is hosted on maven-central nowadays, so I changed the comment on the codemc repo to say "BlockLocker" now.

Here's the bStats page for Brewery where I found the id:
https://bstats.org/plugin/bukkit/Brewery/3494 (ID: 3494)

It is a pretty small change but it's never a bad thing to update stuff and do some chores :)

#### Changes
* Updated bStats version from `1.5` to `2.2.1` (latest at this time)
* Added id parameter to the `Metrics` constructor
* I also went ahead and updated all repositories to use `https://` over the unsecure `http://`