### PR TITLE
Updated Slimefun integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,9 +252,9 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>com.github.TheBusyBiscuit</groupId>
+			<groupId>com.github.slimefun</groupId>
 			<artifactId>Slimefun4</artifactId>
-			<version>RC-21</version>
+			<version>RC-22</version>
 			<scope>provided</scope>
 		</dependency>
 		<!--<dependency>

--- a/src/com/dre/brewery/integration/item/SlimefunPluginItem.java
+++ b/src/com/dre/brewery/integration/item/SlimefunPluginItem.java
@@ -23,7 +23,7 @@ public class SlimefunPluginItem extends PluginItem {
 		try {
 			SlimefunItem sfItem = SlimefunItem.getByItem(item);
 			if (sfItem != null) {
-				return sfItem.getID().equalsIgnoreCase(getItemId());
+				return sfItem.getId().equalsIgnoreCase(getItemId());
 			}
 		} catch (Throwable e) {
 			e.printStackTrace();

--- a/src/com/dre/brewery/integration/item/SlimefunPluginItem.java
+++ b/src/com/dre/brewery/integration/item/SlimefunPluginItem.java
@@ -25,7 +25,7 @@ public class SlimefunPluginItem extends PluginItem {
 			if (sfItem != null) {
 				return sfItem.getId().equalsIgnoreCase(getItemId());
 			}
-		} catch (Throwable e) {
+		} catch (Exception | LinkageError e) {
 			e.printStackTrace();
 			P.p.errorLog("Could not check Slimefun for Item ID");
 			BConfig.hasSlimefun = false;


### PR DESCRIPTION
We have deprecated `SlimefunItem#getID()` back in october as part of Slimefun `RC-17`.
Over half a year later, we would like to remove this deprecated method now but found out that you're still using the deprecated / misspelled method.

This pull request fixes it and updates the code to use the up to date method `SlimefunItem#getId()`, so that we can remove the deprecated method soon.

#### Changes
* Fixed Slimefun dependency info
* Bumped to `RC-22`
* Changed to the correct method `SlimefunItem#getId()`