### PR TITLE
Add icons to display quality

### DIFF
--- a/src/com/dre/brewery/lore/BrewLore.java
+++ b/src/com/dre/brewery/lore/BrewLore.java
@@ -112,8 +112,10 @@ public class BrewLore {
 	 */
 	public void updateIngredientLore(boolean qualityColor) {
 		if (qualityColor && brew.hasRecipe() && !brew.isStripped()) {
-			String prefix = getQualityColor(brew.getIngredients().getIngredientQuality(brew.getCurrentRecipe()));
-			addOrReplaceLore(Type.INGR, prefix, P.p.languageReader.get("Brew_Ingredients"));
+			int quality = brew.getIngredients().getIngredientQuality(brew.getCurrentRecipe());
+			String prefix = getQualityColor(quality);
+			char icon = getQualityIcon(quality);
+			addOrReplaceLore(Type.INGR, prefix, P.p.languageReader.get("Brew_Ingredients"), " " + icon);
 		} else {
 			removeLore(Type.INGR, P.p.languageReader.get("Brew_Ingredients"));
 		}
@@ -132,7 +134,7 @@ public class BrewLore {
 			if (ingredients.getCookedTime() > 1) {
 				prefix = prefix + P.p.languageReader.get("Brew_MinutePluralPostfix");
 			}
-			addOrReplaceLore(Type.COOK, prefix, " " + P.p.languageReader.get("Brew_fermented"));
+			addOrReplaceLore(Type.COOK, prefix, " " + P.p.languageReader.get("Brew_fermented"), " " + getQualityIcon(quality));
 		} else {
 			removeLore(Type.COOK, P.p.languageReader.get("Brew_fermented"));
 		}
@@ -147,8 +149,9 @@ public class BrewLore {
 		if (brew.getDistillRuns() <= 0) return;
 		String prefix;
 		byte distillRuns = brew.getDistillRuns();
+		int quality = brew.getIngredients().getDistillQuality(brew.getCurrentRecipe(), distillRuns);
 		if (qualityColor && !brew.isUnlabeled() && brew.hasRecipe()) {
-			prefix = getQualityColor(brew.getIngredients().getDistillQuality(brew.getCurrentRecipe(), distillRuns));
+			prefix = getQualityColor(quality);
 		} else {
 			prefix = "§7";
 		}
@@ -158,9 +161,9 @@ public class BrewLore {
 			}
 		}
 		if (brew.isUnlabeled() && brew.hasRecipe() && distillRuns < brew.getCurrentRecipe().getDistillRuns()) {
-			addOrReplaceLore(Type.DISTILL, prefix, P.p.languageReader.get("Brew_LessDistilled"));
+			addOrReplaceLore(Type.DISTILL, prefix, P.p.languageReader.get("Brew_LessDistilled"), " " + getQualityIcon(quality));
 		} else {
-			addOrReplaceLore(Type.DISTILL, prefix, P.p.languageReader.get("Brew_Distilled"));
+			addOrReplaceLore(Type.DISTILL, prefix, P.p.languageReader.get("Brew_Distilled"), " " + getQualityIcon(quality));
 		}
 	}
 
@@ -173,8 +176,9 @@ public class BrewLore {
 		if (brew.isStripped()) return;
 		String prefix;
 		float age = brew.getAgeTime();
+		int quality = brew.getIngredients().getAgeQuality(brew.getCurrentRecipe(), age);
 		if (qualityColor && !brew.isUnlabeled() && brew.hasRecipe()) {
-			prefix = getQualityColor(brew.getIngredients().getAgeQuality(brew.getCurrentRecipe(), age));
+			prefix = getQualityColor(quality);
 		} else {
 			prefix = "§7";
 		}
@@ -187,7 +191,7 @@ public class BrewLore {
 				prefix = prefix + P.p.languageReader.get("Brew_HundredsOfYears") + " ";
 			}
 		}
-		addOrReplaceLore(Type.AGE, prefix, P.p.languageReader.get("Brew_BarrelRiped"));
+		addOrReplaceLore(Type.AGE, prefix, P.p.languageReader.get("Brew_BarrelRiped"), " " + getQualityIcon(quality));
 	}
 
 	/**
@@ -198,7 +202,7 @@ public class BrewLore {
 	public void updateWoodLore(boolean qualityColor) {
 		if (qualityColor && brew.hasRecipe() && !brew.isUnlabeled()) {
 			int quality = brew.getIngredients().getWoodQuality(brew.getCurrentRecipe(), brew.getWood());
-			addOrReplaceLore(Type.WOOD, getQualityColor(quality), P.p.languageReader.get("Brew_Woodtype"));
+			addOrReplaceLore(Type.WOOD, getQualityColor(quality), P.p.languageReader.get("Brew_Woodtype"), " " + getQualityIcon(quality));
 		} else {
 			removeLore(Type.WOOD, P.p.languageReader.get("Brew_Woodtype"));
 		}
@@ -326,11 +330,24 @@ public class BrewLore {
 	 * @param type The Type of BrewLore to replace
 	 * @param prefix The Prefix to add to the line of lore
 	 * @param line The Line of Lore to add or replace
- 	 */
+	 */
 	public int addOrReplaceLore(Type type, String prefix, String line) {
+		return addOrReplaceLore(type, prefix, line, "");
+	}
+
+	/**
+	 * Adds or replaces a line of Lore.
+	 * <p>Searches for type and if not found for Substring lore and replaces it
+	 *
+	 * @param type The Type of BrewLore to replace
+	 * @param prefix The Prefix to add to the line of lore
+	 * @param line The Line of Lore to add or replace
+	 * @param suffix The Suffix to add to the line of lore
+	 */
+	public int addOrReplaceLore(Type type, String prefix, String line, String suffix) {
 		int index = type.findInLore(lore);
 		if (index > -1) {
-			lore.set(index, type.id + prefix + line);
+			lore.set(index, type.id + prefix + line + suffix);
 			return index;
 		}
 
@@ -339,7 +356,7 @@ public class BrewLore {
 		if (index > -1) {
 			lore.remove(index);
 		}
-		return addLore(type, prefix, line);
+		return addLore(type, prefix, line, suffix);
 	}
 
 	/**
@@ -348,17 +365,28 @@ public class BrewLore {
 	 * @param type The Type of BrewLore to add
 	 * @param prefix The Prefix to add to the line of lore
 	 * @param line The Line of Lore to add or add
- 	 */
+	 */
 	public int addLore(Type type, String prefix, String line) {
+		return addLore(type, prefix, line, "");
+	}
+	/**
+	 * Adds a line of Lore in the correct ordering
+	 *
+	 * @param type The Type of BrewLore to add
+	 * @param prefix The Prefix to add to the line of lore
+	 * @param line The Line of Lore to add or add
+	 * @param suffix The Suffix to add to the line of lore
+	 */
+	public int addLore(Type type, String prefix, String line, String suffix) {
 		lineAddedOrRem = true;
 		for (int i = 0; i < lore.size(); i++) {
 			Type existing = Type.get(lore.get(i));
 			if (existing != null && existing.isAfter(type)) {
-				lore.add(i, type.id + prefix + line);
+				lore.add(i, type.id + prefix + line + suffix);
 				return i;
 			}
 		}
-		lore.add(type.id + prefix + line);
+		lore.add(type.id + prefix + line + suffix);
 		return lore.size() - 1;
 	}
 
@@ -508,6 +536,28 @@ public class BrewLore {
 			color = "&4";
 		}
 		return P.p.color(color);
+	}
+
+	/**
+	 * Gets the icon representing a quality for use in lore
+	 *
+	 * @param quality The quality used for the icon
+	 * @return The icon for the given quality
+	 */
+	public static char getQualityIcon(int quality) {
+		char icon;
+		if (quality > 8) {
+			icon = '\u2605';
+		} else if (quality > 6) {
+			icon = '\u2BEA';
+		} else if (quality > 4) {
+			icon = '\u2606';
+		} else if (quality > 2) {
+			icon = '\u2718';
+		} else {
+			icon = '\u2620';
+		}
+		return icon;
 	}
 
 	/**


### PR DESCRIPTION
Resolves #493.
This pr adds an icon to the end of the quality labels to further convey the quality of the attribute. 
This makes the quality labels colorblind-friendly and makes it not solely relied on color.

The current icons are:
9-10 (Green): Filled in star
7-8 (Yellow): Half filled in star
5-6 (Orange): Empty star
3-4 (Red): Cross mark
0-2 (Dark red): Skull

Example images:
![image](https://user-images.githubusercontent.com/37024464/182073854-41fec991-6dce-47ae-919d-ee509754d435.png)
![image](https://user-images.githubusercontent.com/37024464/182073848-91d6ea0c-6432-428b-a770-846816c6858a.png)
