### PR TITLE
Have ruined brews display random information about what went wrong

### DIFF
--- a/resources/languages/en.yml
+++ b/resources/languages/en.yml
@@ -49,6 +49,22 @@ Error_UnknownCommand: Unknown Command
 Error_YmlRead: 'Could not read file config.yml, please make sure the file is in valid yml format (correct spaces, using '' '' etc.)'
 Error_NoPlayer: 'Player not found: &v1'
 
+# User errors
+UserError_BadIngredientKind_1: 'Eugh, the taste of the &v1 clashes with the other ingredients...'
+UserError_BadIngredientKind_2: 'The &v1 doesn''t taste very good here...'
+UserError_BadIngredientKind_3: 'There''s something in here that shouldn''t be in here...'
+UserError_MissingIngredientKind_1: 'Seems like something''s missing...'
+UserError_MissingIngredientKind_2: 'This would be better with some &v1...'
+UserError_MissingIngredientKind_3: 'Missing &v1...'
+UserError_IngredientQuantity_TooMuch_1: 'Whoa, that''s definitely too much &v1!'
+UserError_IngredientQuantity_TooMuch_2: 'That''s a lot of &v1...'
+UserError_IngredientQuantity_TooLittle_1: 'It could do with a bit more of the taste of &v1...'
+UserError_IngredientQuantity_TooLittle_2: 'Not getting enough of that &v1 in here.'
+UserError_NeededDistillation_1: 'There''s something in here that shouldn''t be in here...'
+UserError_NeededDistillation_2: 'I think this needs some distillation...'
+UserError_DidntNeedDistillation_1: 'Seems like something''s missing...'
+UserError_DidntNeedDistillation_2: 'I think this didn''t need distillation...'
+
 # Etc
 Etc_Barrel: Barrel
 Etc_Page: Page

--- a/src/com/dre/brewery/Brew.java
+++ b/src/com/dre/brewery/Brew.java
@@ -4,8 +4,10 @@ import com.dre.brewery.api.events.brew.BrewModifyEvent;
 import com.dre.brewery.filedata.BConfig;
 import com.dre.brewery.filedata.ConfigUpdater;
 import com.dre.brewery.lore.*;
+import com.dre.brewery.lore.BrewLore.Type;
 import com.dre.brewery.recipe.BEffect;
 import com.dre.brewery.recipe.BRecipe;
+import com.dre.brewery.recipe.BUserError;
 import com.dre.brewery.recipe.PotionColor;
 import com.dre.brewery.utility.BUtil;
 import org.bukkit.Material;
@@ -637,8 +639,10 @@ public class Brew implements Cloneable {
 			recipe.getColor().colorBrew(potionMeta, slotItem, canDistill());
 
 		} else {
+			BUserError error = ingredients.getError(wood, ageTime, distillRuns > 0);
 			quality = 0;
 			lore.removeEffects();
+			lore.addOrReplaceLore(Type.ERROR, "", error.userMessage());
 			potionMeta.setDisplayName(P.p.color("&f" + P.p.languageReader.get("Brew_DistillUndefined")));
 			PotionColor.GREY.colorBrew(potionMeta, slotItem, canDistill());
 		}
@@ -709,9 +713,11 @@ public class Brew implements Cloneable {
 				potionMeta.setDisplayName(P.p.color("&f" + recipe.getName(quality)));
 				recipe.getColor().colorBrew(potionMeta, item, canDistill());
 			} else {
+				BUserError error = ingredients.getError(wood, ageTime, distillRuns > 0);
 				quality = 0;
 				lore.convertLore(false);
 				lore.removeEffects();
+				lore.addOrReplaceLore(Type.ERROR, "", error.userMessage());
 				currentRecipe = null;
 				potionMeta.setDisplayName(P.p.color("&f" + P.p.languageReader.get("Brew_BadPotion")));
 				PotionColor.GREY.colorBrew(potionMeta, item, canDistill());

--- a/src/com/dre/brewery/integration/item/BreweryPluginItem.java
+++ b/src/com/dre/brewery/integration/item/BreweryPluginItem.java
@@ -27,4 +27,9 @@ public class BreweryPluginItem extends PluginItem {
 		}
 		return false;
 	}
+
+	@Override
+	public String displayName() {
+		return getItemId();
+	}
 }

--- a/src/com/dre/brewery/integration/item/MMOItemsPluginItem.java
+++ b/src/com/dre/brewery/integration/item/MMOItemsPluginItem.java
@@ -30,4 +30,9 @@ public class MMOItemsPluginItem extends PluginItem {
 			return false;
 		}
 	}
+
+	@Override
+	public String displayName() {
+		return getItemId();
+	}
 }

--- a/src/com/dre/brewery/integration/item/SlimefunPluginItem.java
+++ b/src/com/dre/brewery/integration/item/SlimefunPluginItem.java
@@ -30,4 +30,9 @@ public class SlimefunPluginItem extends PluginItem {
 		}
 		return false;
 	}
+
+	@Override
+	public String displayName() {
+		return SlimefunItem.getById(getItemId()).getItemName();
+	}
 }

--- a/src/com/dre/brewery/lore/BrewLore.java
+++ b/src/com/dre/brewery/lore/BrewLore.java
@@ -523,7 +523,8 @@ public class BrewLore {
 		DISTILL("§p"),
 		AGE("§y"),
 		WOOD("§z"),
-		ALC("§q");
+		ALC("§q"),
+		ERROR("§o");
 
 		public final String id;
 

--- a/src/com/dre/brewery/recipe/BRecipe.java
+++ b/src/com/dre/brewery/recipe/BRecipe.java
@@ -494,6 +494,16 @@ public class BRecipe {
 		return 0;
 	}
 
+	@Nullable
+	public RecipeItem recipeItemFor(Ingredient ing) {
+		for (RecipeItem rItem : ingredients) {
+			if (rItem.matches(ing)) {
+				return rItem;
+			}
+		}
+		return null;
+	}
+
 	/**
 	 * how many of a specific ingredient in the recipe
 	 */

--- a/src/com/dre/brewery/recipe/BUserError.java
+++ b/src/com/dre/brewery/recipe/BUserError.java
@@ -1,0 +1,79 @@
+package com.dre.brewery.recipe;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.dre.brewery.P;
+
+public interface BUserError {
+    public String userMessage();
+
+    public class BadIngredientKindError implements BUserError {
+        private Ingredient excessItemStack;
+
+        public BadIngredientKindError(Ingredient of) {
+            this.excessItemStack = of;
+        }
+
+        @Override
+        public String userMessage() {
+            int messagePermutation = ThreadLocalRandom.current().nextInt(1, 3+1);
+            return P.p.languageReader.get("UserError_BadIngredientKind_"+messagePermutation, excessItemStack.displayName());
+        }
+    }
+    public class MissingIngredientKindError implements BUserError {
+        private RecipeItem missingItem;
+
+        public MissingIngredientKindError(RecipeItem missingItem) {
+            this.missingItem = missingItem;
+        }
+
+        @Override
+        public String userMessage() {
+            int messagePermutation = ThreadLocalRandom.current().nextInt(1, 3+1);
+            return P.p.languageReader.get("UserError_MissingIngredientKind_"+messagePermutation, missingItem.displayName());
+        }
+    }
+    public class IngredientQuantityError implements BUserError {
+        private RecipeItem item;
+        private int actualCount;
+
+        public IngredientQuantityError(RecipeItem item, int actualCount) {
+            this.item = item;
+            this.actualCount = actualCount;
+        }
+
+        @Override
+        public String userMessage() {
+            int messagePermutation = ThreadLocalRandom.current().nextInt(1, 2+1);
+            if (actualCount < item.getAmount()) {
+                return P.p.languageReader.get("UserError_IngredientQuantity_TooLittle_" + messagePermutation, item.displayName());
+            } else if (actualCount > item.getAmount()) {
+                return P.p.languageReader.get("UserError_IngredientQuantity_TooMuch_" + messagePermutation, item.displayName());
+            }
+
+            return "";
+        }
+    }
+    public class DistillationError implements BUserError {
+        private boolean actuallyDistilled;
+        private boolean neededDistillation;
+
+        public DistillationError(boolean actuallyDistilled, boolean neededDistillation) {
+            this.actuallyDistilled = actuallyDistilled;
+            this.neededDistillation = neededDistillation;
+        }
+
+        @Override
+        public String userMessage() {
+            int messagePermutation = ThreadLocalRandom.current().nextInt(1, 2+1);
+
+            if (actuallyDistilled && !neededDistillation) {
+                return P.p.languageReader.get("UserError_DidntNeedDistillation_" + messagePermutation);
+            } else if (neededDistillation && !actuallyDistilled) {
+                return P.p.languageReader.get("UserError_NeededDistillation_" + messagePermutation);
+            }
+
+            return "";
+        }
+    }
+}

--- a/src/com/dre/brewery/recipe/CustomItem.java
+++ b/src/com/dre/brewery/recipe/CustomItem.java
@@ -289,4 +289,9 @@ public class CustomItem extends RecipeItem implements Ingredient {
 	public static void registerItemLoader(P p) {
 		p.registerForItemLoader("CI", CustomItem::loadFrom);
 	}
+
+	@Override
+	public String displayName() {
+		return this.name;
+	}
 }

--- a/src/com/dre/brewery/recipe/CustomMatchAnyItem.java
+++ b/src/com/dre/brewery/recipe/CustomMatchAnyItem.java
@@ -228,4 +228,9 @@ public class CustomMatchAnyItem extends RecipeItem {
 			", loresize: " + (lore != null ? lore.size() : 0) +
 			'}';
 	}
+
+	@Override
+	public String displayName() {
+		return String.format("One of %s", String.join(", ", this.names));
+	}
 }

--- a/src/com/dre/brewery/recipe/Ingredient.java
+++ b/src/com/dre/brewery/recipe/Ingredient.java
@@ -56,5 +56,6 @@ public interface Ingredient {
 	 */
 	boolean isSimilar(Ingredient item);
 
+	String displayName();
 
 }

--- a/src/com/dre/brewery/recipe/PluginItem.java
+++ b/src/com/dre/brewery/recipe/PluginItem.java
@@ -152,6 +152,10 @@ public abstract class PluginItem extends RecipeItem implements Ingredient {
 					public boolean matches(ItemStack item) {
 						return false;
 					}
+					@Override
+					public String displayName() {
+						return "Invalid Item";
+					}
 				};
 			}
 			return item;

--- a/src/com/dre/brewery/recipe/RecipeItem.java
+++ b/src/com/dre/brewery/recipe/RecipeItem.java
@@ -77,6 +77,11 @@ public abstract class RecipeItem implements Cloneable {
 	public abstract List<Material> getMaterials();
 
 	/**
+	 * @return A user-displayable name for this recipeItem
+	 */
+	public abstract String displayName();
+
+	/**
 	 * @return The Id this Item uses in the config in the custom-items section
 	 */
 	@Nullable

--- a/src/com/dre/brewery/recipe/SimpleItem.java
+++ b/src/com/dre/brewery/recipe/SimpleItem.java
@@ -148,5 +148,12 @@ public class SimpleItem extends RecipeItem implements Ingredient {
 		p.registerForItemLoader("SI", SimpleItem::loadFrom);
 	}
 
+	@Override
+	public String displayName() {
+		// approximate a user-friendly display name since
+		// server doesn't have access to translations :/
+		return mat.toString().toLowerCase().replace("_", " ");
+	}
+
 }
 


### PR DESCRIPTION
When you're trying to discover new brews but haven't gotten close enough to one in order
to get precise quality information, having just the 'you failed' leads to an unengaging
experience, since you're shooting completely in the dark.

This commit aims to remove the helplessness of having no information about how close you
are to getting something that works, while not being overly revealing of the server's secrets.

This is achieved by introducing a system to figure out the set of mistakes made by players
between the set of ingredients and current brew state and the ideal recipe.
This is then thrown through several layers of uncertainty:
- which recipe's mistake to display (from the set of recipes that have the least amount of mistakes, i.e. if there are 10 mistake recipes and 2 of them are tied for least mistakes, one of the 2 will be randomly selected.)
- which mistake to display
- how much information can be gleaned out of the lore text

The randomness is balanced so that the player will always be pointed in roughly the correct direction to a recipe,
but will never have a direct beeline to one.

![grafik](https://user-images.githubusercontent.com/20326855/183225910-b0749a42-01ef-495c-97ec-79e188d216d9.png)
![grafik](https://user-images.githubusercontent.com/20326855/183225916-9ae7f572-56d8-4f0d-b797-022b0e9c1deb.png)
