### PR TITLE
Hopper-distillery compatibility

### DIFF
--- a/src/com/dre/brewery/BDistiller.java
+++ b/src/com/dre/brewery/BDistiller.java
@@ -14,6 +14,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * Updated for 1.9 to replicate the "Brewing" process for distilling.
@@ -48,8 +49,7 @@ public class BDistiller {
 		taskId = new DistillRunnable().runTaskTimer(P.p, 2L, 1L).getTaskId();
 	}
 
-	public static void distillerClick(InventoryClickEvent event) {
-		BrewerInventory standInv = (BrewerInventory) event.getInventory();
+	public static void distillerClick(BrewerInventory standInv) {
 		final Block standBlock = standInv.getHolder().getBlock();
 
 		// If we were already tracking the brewer, cancel any ongoing event due to the click.


### PR DESCRIPTION
# Current situation

Whenever a brewing potion has been inserted into a distillery using hoppers, the item is there, but no distilling is initiated.

# What these changes do

Applies the same checks that are done whenever a player takes/removes an item from the distillery to hoppers moving/removing items.

- Should not increase the lag that much (if any), as most of the code is hidden behind type checks; Only hopper movement of potions into and from distilleries are considered.
- I would not say this breaks immersion, as one can already insert the potion into the distiller; keeping it as is does not make any sense as the item can be inside of the distiller without initiating a distill run.

I can add an option for this, if that's deemed necessary.
